### PR TITLE
Fix environment variable names in diagnose_api.py

### DIFF
--- a/diagnose_api.py
+++ b/diagnose_api.py
@@ -201,9 +201,9 @@ def test_refactored_code():
 
         # Test nationalRailLogin
         print("\nTesting nationalRailLogin()...")
-        api_key = os.getenv('DARWIN_API_KEY')
+        api_key = os.getenv('DARWIN_WEBSERVICE_API_KEY')
         wsdl_url = os.getenv(
-            'DARWIN_WSDL',
+            'DARWIN_WEBSERVICE_WSDL',
             'https://lite.realtime.nationalrail.co.uk/OpenLDBWS/wsdl.aspx'
         )
 


### PR DESCRIPTION
## Summary
- Fixed inconsistent environment variable names in `diagnose_api.py` lines 204-208
- Updated `DARWIN_API_KEY` → `DARWIN_WEBSERVICE_API_KEY`
- Updated `DARWIN_WSDL` → `DARWIN_WEBSERVICE_WSDL`

## Problem
The `test_refactored_code()` function in `diagnose_api.py` was using old environment variable names (`DARWIN_API_KEY` and `DARWIN_WSDL`) that are inconsistent with:
- The same file's earlier code (lines 60, 76) which uses `DARWIN_WEBSERVICE_*` naming
- The naming convention used throughout the codebase in test files and other modules
- The documentation which specifies `DARWIN_WEBSERVICE_API_KEY`

## Solution
Updated the environment variable lookups to use the consistent naming convention, preserving the existing default WSDL URL fallback.

## Testing
- [x] Code review - changes are consistent with rest of file
- [ ] Manual testing - verify diagnose_api.py works with .env file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal test configuration environment variable naming conventions for API authentication.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->