### PR TITLE
Reduce logging noise and remove obsolete email config

### DIFF
--- a/UKTrains.indigoPlugin/Contents/Server Plugin/PluginConfig.xml
+++ b/UKTrains.indigoPlugin/Contents/Server Plugin/PluginConfig.xml
@@ -133,24 +133,6 @@
         <Label>Generate Modern Board Image</Label>
         <Description>414×variable portrait - mobile-optimized for messaging apps</Description>
     </Field>
-    <Field id="simpleSeparator4" type="separator"/>
-    <Field
-		id = "updaterEmailsEnabled"
-		type = "checkbox"
-		defaultValue = "false"
-		tooltip  =  "Enables (disables) email notifications.">
-		<Label>Check to enable email communications on updates to plugin</Label>
-		<Description>Enable/Disable email version updates</Description>
-	</Field>
-	<Field
-		id = "updaterEmail"
-		type = "textfield"
-		visibleBindingId = "updaterEmailsEnabled"
-		visibleBindingValue = "true"
-		tooltip = "Please enter the email address to receive notifications of updates to the plugin.">
-		<Label>What email address should be used?:</Label>
-	</Field>
-
     <Field id="simpleSeparator10" type="separator"/>
     <Field id="checkboxDebug1"
            type="checkbox"

--- a/UKTrains.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/UKTrains.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -391,7 +391,7 @@ def routeUpdate(dev, apiAccess, networkrailURL, paths, logger, plugin_prefs=None
 
 	if current_hash != previous_hash:
 		# Content changed - regenerate image
-		logger.info(f"Board content changed for '{dev.name}', regenerating image")
+		logger.debug(f"Board content changed for '{dev.name}', regenerating image")
 
 		image_success = _generate_departure_image(
 			paths.plugin_root,


### PR DESCRIPTION
## Summary
- Changed board regeneration logging from `info` to `debug` level to reduce log clutter
- Removed obsolete email notification configuration fields

## Changes

### Logging Reduction
- **plugin.py:394**: Changed `logger.info()` to `logger.debug()` for board regeneration messages
- Board regeneration messages now only appear when debug mode is enabled
- Reduces log noise from frequent image updates (every 60 seconds by default)

### Configuration Cleanup
- **PluginConfig.xml**: Removed email notification fields
  - Removed `updaterEmailsEnabled` checkbox
  - Removed `updaterEmail` textfield
- Indigo now handles version updates automatically, making these fields obsolete

## Test Plan
- [x] Verify plugin still loads and runs correctly
- [x] Confirm board regeneration works (messages only in debug mode)
- [x] Check plugin config UI displays correctly without email fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed email notification configuration options from plugin settings UI.

* **Refactor**
  * Adjusted logging verbosity for content update operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->