### PR TITLE
Fix cancelled train parsing in modern departure board

### DIFF
--- a/UKTrains.indigoPlugin/Contents/Server Plugin/image_generator.py
+++ b/UKTrains.indigoPlugin/Contents/Server Plugin/image_generator.py
@@ -431,16 +431,16 @@ def _format_station_board(
 				destination = parts[0] + '-' * 50
 				platform = parts[1] + '-' * 10  # Platform field
 				schedule = parts[2] + '-' * 10
-				estimated = parts[3] + '-' * 10
+				estimated = parts[3] + '-' * 15
 				operator = parts[4]
-				board_line = destination[:25] + platform[:5] + ' ' + schedule[:10] + estimated[:10] + operator
+				board_line = destination[:25] + platform[:5] + ' ' + schedule[:10] + estimated[:15] + operator
 			elif len(parts) >= 4:
 				# Legacy format without platform (backwards compatibility)
 				destination = parts[0] + '-' * 50
 				schedule = parts[1] + '-' * 10
-				estimated = parts[2] + '-' * 10
+				estimated = parts[2] + '-' * 15
 				operator = parts[3]
-				board_line = destination[:35] + ' ' + schedule[:10] + estimated[:10] + operator
+				board_line = destination[:35] + ' ' + schedule[:10] + estimated[:15] + operator
 			else:
 				# Malformed line, keep as is
 				board_line = current_line


### PR DESCRIPTION
## Summary
- Widened estimated/status column from 10 to 15 chars in `_format_station_board` so "Cancelled" (9 chars) gets enough dash padding for the `---` separator pattern
- Added fallback parser in `parse_service_data` for 3-field lines where status words (Cancelled, Delayed, etc.) merged with operator name due to insufficient dash separators

## Test plan
- [ ] Verify cancelled trains now appear on modern departure board instead of being skipped
- [ ] Check no orphaned calling points warnings for cancelled services
- [ ] Confirm classic board rendering unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of service data with merged status and operator information.
  * Enhanced error handling and logging for malformed service records.

* **Style**
  * Expanded allocated space for estimated time display in station boards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->