### PR TITLE
Bump version to 2026.0.2

### DIFF
--- a/UKTrains.indigoPlugin/Contents/Info.plist
+++ b/UKTrains.indigoPlugin/Contents/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>PluginVersion</key>
-	<string>2026.0.1</string>
+	<string>2026.0.2</string>
 	<key>ServerApiVersion</key>
 	<string>3.0</string>
 	<key>IwsApiVersion</key>


### PR DESCRIPTION
## Summary
- Bump PluginVersion to 2026.0.2 for cancelled train parsing fix (#10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 2026.0.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->