### PR TITLE
fix: prevent board generation logging unless debug enabled

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,6 +282,6 @@ Station codes loaded from [stationCodes.txt](UKTrains.indigoPlugin/Contents/Serv
 
 1. **Use `/indigo` skill** for all Indigo plugin development tasks
 2. **Subprocess calls** must use explicit Python path, not `sys.executable`
-3. **Diagnostic logging** is enabled by default for image generation (can be disabled after confirming stable)
+3. **Diagnostic logging** for image generation only appears when debug mode is enabled
 4. **Test deployment** on actual Indigo Mac before assuming fixes work
 5. **Version bumps** should follow semantic versioning in Info.plist

--- a/UKTrains.indigoPlugin/Contents/Info.plist
+++ b/UKTrains.indigoPlugin/Contents/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>PluginVersion</key>
-	<string>2026.0.2</string>
+	<string>2026.0.3</string>
 	<key>ServerApiVersion</key>
 	<string>3.0</string>
 	<key>IwsApiVersion</key>

--- a/UKTrains.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/UKTrains.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -85,6 +85,7 @@ class PluginLogger:
 		"""
 		self.logger = logging.getLogger(f'Plugin.{plugin_id}')
 		self.logger.setLevel(logging.DEBUG if debug else logging.INFO)
+		self.logger.propagate = False  # Prevent messages leaking to Indigo Event Log
 
 		# Remove existing handlers
 		self.logger.handlers.clear()


### PR DESCRIPTION
## Summary
- Add `propagate=False` to PluginLogger to prevent board generation log messages leaking to Indigo Event Log via Python's logging hierarchy
- Board generation messages already use `logger.debug()` but were propagating to parent loggers
- Bump version to 2026.0.3

## Test plan
- [ ] Enable plugin with debug OFF — verify no board generation messages in Indigo Event Log
- [ ] Enable debug mode — verify board generation messages appear in UKTrains.log
- [ ] Confirm plugin starts and generates boards normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate log messages appearing in the Indigo Event Log.
  * Image generation diagnostic logging now appears only when debug mode is enabled, reducing log noise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->