### PR TITLE
fix: exclude train devices from SQL Logger history

### DIFF
--- a/UKTrains.indigoPlugin/Contents/Info.plist
+++ b/UKTrains.indigoPlugin/Contents/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>PluginVersion</key>
-	<string>2026.0.3</string>
+	<string>2026.0.4</string>
 	<key>ServerApiVersion</key>
 	<string>3.0</string>
 	<key>IwsApiVersion</key>

--- a/UKTrains.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/UKTrains.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -662,6 +662,11 @@ class Plugin(indigo.PluginBase):
 	########################################
 	def deviceStartComm(self, dev):
 		dev.stateListOrDisplayStateIdChanged()  # Ensure latest devices.xml is being used
+		# Exclude train devices from SQL Logger (frequent updates with many empty states cause errors)
+		if dev.sharedProps.get("sqlLoggerIgnoreStates") != "*":
+			shared = dev.sharedProps
+			shared["sqlLoggerIgnoreStates"] = "*"
+			dev.replaceSharedPropsOnServer(shared)
 		if dev.pluginProps['routeActive']:
 			dev.updateStateOnServer('deviceActive', True)
 		else:


### PR DESCRIPTION
## Summary
- Sets `sqlLoggerIgnoreStates="*"` on train device shared props at device start
- Prevents SQL Logger errors caused by frequent train state updates with many empty string values

## Test plan
- [ ] Verify train devices start without SQL Logger errors
- [ ] Confirm `sqlLoggerIgnoreStates` property is set on device shared props

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin version to 2026.0.4.

* **Bug Fixes**
  * Ensured train devices have correct logging configuration automatically applied during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->