### PR TITLE
docs: refresh codebase map and add workspace header

### DIFF
--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -1,173 +1,119 @@
-# Architecture
+# ARCHITECTURE
 
-**Analysis Date:** 2026-02-01
+## Plugin Lifecycle
 
-## Pattern Overview
+Standard Indigo `PluginBase` subclass in `plugin.py`:
 
-**Overall:** Modular Layered Architecture
+```
+__init__()      — initialize PluginConfig, PluginPaths, PluginLogger, Pydantic validation
+startup()       — update log level, iterate devices for state refresh
+runConcurrentThread()  — main polling loop (runs forever until StopThread)
+shutdown()      — log shutdown
+deviceStartComm()  — set sqlLoggerIgnoreStates="*", sync deviceActive state
+deviceStopComm()   — no-op
+```
 
-**Key Characteristics:**
-- Event-driven plugin lifecycle managed by Indigo framework
-- Concurrent polling pattern for periodic API updates
-- Separation of concerns with dedicated modules for each functional area
-- Asynchronous subprocess spawning for image generation (avoids shared library conflicts)
-- State-based device model mapping to Indigo's device/state abstraction
+`runConcurrentThread()` is the heartbeat. Each iteration:
+1. Loads `RuntimeConfig` from `self.pluginPrefs`
+2. Writes `trainparameters.txt` (color/font config for image generation)
+3. Iterates `indigo.devices.iter('self.trainTimetable')`
+4. Calls `routeUpdate(dev, ...)` for each active device
+5. Sleeps `runtime_config.refresh_freq` seconds (default 60, min 30, max 600)
 
-## Layers
+**Known issue**: `indigo.debugger()` is called unconditionally at line 789 inside
+`runConcurrentThread()` — this will pause the plugin waiting for a debugger connection.
 
-**Plugin Base Layer:**
-- Purpose: Indigo plugin lifecycle management and device control
-- Location: `UKTrains.indigoPlugin/Contents/Server Plugin/plugin.py` (main class at line 659+)
-- Contains: Plugin class extending `indigo.PluginBase`, startup/shutdown hooks, concurrent thread loop
-- Depends on: All other modules for delegated functionality
-- Used by: Indigo framework; entry point for all plugin operations
+## Device Types
 
-**API Wrapper Layer:**
-- Purpose: Encapsulate Darwin SOAP webservice communication with retry logic
-- Location: `UKTrains.indigoPlugin/Contents/Server Plugin/darwin_api.py`
-- Contains: `nationalRailLogin()`, `_fetch_station_board()`, `_fetch_service_details()` with retry decorators
-- Depends on: `nredarwin.webservice.DarwinLdbSession` (ZEEP SOAP client)
-- Used by: Device manager layer for fetching real-time train data
+One device type: `trainTimetable` (defined in `Devices.xml`).
 
-**SOAP Client Library:**
-- Purpose: Low-level SOAP communication with National Rail Darwin API
-- Location: `UKTrains.indigoPlugin/Contents/Server Plugin/nredarwin/webservice.py`
-- Contains: `DarwinLdbSession` class wrapping ZEEP client with authentication header building
-- Depends on: `zeep` (SOAP client library), `requests` (HTTP transport)
-- Used by: Darwin API wrapper layer
+Each device represents a single departure route:
+- **Origin station**: CRS code + long name stored in device states
+- **Destination**: CRS code + long name (or `ALL` for all destinations)
+- **Active toggle**: `routeActive` prop / `deviceActive` state
+- **States**: 10 train slots × 9 states each + station-level metadata
 
-**Device Management Layer:**
-- Purpose: Update Indigo device states with train data; aggregate station-level status
-- Location: `UKTrains.indigoPlugin/Contents/Server Plugin/device_manager.py`
-- Contains: `_process_train_services()`, `_update_train_device_states()`, `_clear_device_states()`, calling point processing
-- Depends on: Text formatter (for delay calculations), Darwin API wrapper (for service details)
-- Used by: Main plugin loop via `routeUpdate()`
+Per-train states (trainN prefix, N=1..10):
+`Dest`, `Op`, `Sch`, `Est`, `Delay`, `Issue` (bool), `Reason`, `Calling`, `Platform`
 
-**Text Formatting Layer:**
-- Purpose: Pure utility functions for time/date handling and delay calculations
-- Location: `UKTrains.indigoPlugin/Contents/Server Plugin/text_formatter.py`
-- Contains: `getUKTime()`, `delayCalc()`, `formatSpecials()` (HTML stripping)
-- Depends on: `pytz` (optional; falls back to GMT), `constants` for status enums
-- Used by: Device manager and image generator layers
+Station-level states:
+`stationLong`, `stationCRS`, `destinationLong`, `destinationCRS`, `timeGenerated`,
+`stationMessages`, `stationIssues` (bool), `imageGenerationStatus`, `imageGenerationError`,
+`image_content_hash`, `deviceStatus`, `deviceActive`
 
-**Image Generation Layer:**
-- Purpose: Coordinate text file writing and subprocess spawning for PNG board generation
-- Location: `UKTrains.indigoPlugin/Contents/Server Plugin/image_generator.py`
-- Contains: `_write_departure_board_text()`, `_generate_departure_image()`, `_format_station_board()`
-- Depends on: `text2png.py` subprocess (separate Python process), text formatter (for delays)
-- Used by: Main route update flow
+Device status icons:
+- `SensorOn` = on time
+- `SensorTripped` = delays/issues
+- `SensorOff` = inactive or update failed
 
-**Configuration Layer:**
-- Purpose: Centralize configuration management and path resolution
-- Location: `UKTrains.indigoPlugin/Contents/Server Plugin/config.py`
-- Contains: `RuntimeConfig`, `PluginConfig`, `PluginPaths` dataclasses with validation
-- Depends on: `constants` (for defaults)
-- Used by: Plugin main class and concurrent thread for reading preferences
-
-**Constants Layer:**
-- Purpose: Single source of truth for magic numbers, API endpoints, color schemes
-- Location: `UKTrains.indigoPlugin/Contents/Server Plugin/constants.py`
-- Contains: Train limits, Darwin API config, image dimensions, color schemes as dataclasses
-- Depends on: Nothing (leaf module)
-- Used by: All other modules
+SQL Logger is disabled for all states (`sqlLoggerIgnoreStates = "*"`) because frequent
+updates across 90 states cause errors.
 
 ## Data Flow
 
-**Route Update Cycle (main business process):**
+```
+runConcurrentThread()
+  └─ routeUpdate(dev, api_key, darwin_url, paths, logger, plugin_prefs)   [plugin.py]
+       ├─ nationalRailLogin(url, key)                                       [darwin_api.py]
+       ├─ _clear_device_states(dev)                                        [device_manager.py]
+       ├─ _fetch_station_board(session, start_crs, end_crs)                [darwin_api.py]
+       ├─ _process_train_services(dev, session, board, image_content, ...) [device_manager.py]
+       │    └─ for each service:
+       │         ├─ _fetch_service_details(session, service_id)            [darwin_api.py]
+       │         ├─ _update_train_device_states(dev, trainNum, ...)        [device_manager.py]
+       │         └─ _append_train_to_image(image_content, ...)             [image_generator.py]
+       ├─ _update_station_issues_flag(dev)                                 [device_manager.py]
+       ├─ _process_special_messages(board, dev)                            [device_manager.py]
+       ├─ _format_station_board(image_content, ...)                        [image_generator.py]
+       ├─ _write_departure_board_text(text_path, ...)                      [image_generator.py]
+       ├─ compute_board_content_hash(text_path, params_path)               [image_generator.py]
+       └─ _generate_departure_image(...)                                   [image_generator.py]
+            └─ _generate_single_image(..., board_style='classic'|'modern')
+                 └─ subprocess: python3 text2png.py [args]
+                      └─ (if modern) text2png_modern.py
+```
 
-1. **Trigger:** Plugin concurrent thread at line 745 loops every N seconds
-2. **Load Config:** RuntimeConfig loaded from pluginPrefs
-3. **For each device:** Call `routeUpdate()` at line 281
-4. **Authenticate:** `nationalRailLogin()` opens SOAP session (darwin_api.py:150)
-5. **Fetch Board:** `_fetch_station_board()` queries Darwin API for station departures (darwin_api.py:82)
-6. **Process Services Loop:** For each train (up to 10):
-   - `_fetch_service_details()` fetches full service info with calling points (darwin_api.py:124)
-   - `_update_train_device_states()` updates device states with time/delay/operator info (device_manager.py:137)
-   - `_append_train_to_image()` formats train for image output (image_generator.py)
-7. **Update Station Status:** `_update_station_issues_flag()` aggregates all trains for delays flag (device_manager.py:44)
-8. **Generate Image:** Subprocess spawned to convert text file to PNG via `text2png.py` (image_generator.py:52)
-9. **Next Cycle:** Sleep for refresh_freq seconds (plugin.py:830)
+## Image Generation Subsystem
 
-**State Management:**
+Images are generated in a **separate Python subprocess** to avoid shared library conflicts
+between Pillow and Indigo's embedded Python environment.
 
-- Device state: Organized as train1-train10 with suffixes (Dest, Sch, Est, Delay, Issue, Reason, Calling, Op)
-- Station-level state: stationIssues boolean aggregates all train Issues; deviceStatus shows human-readable status
-- Config state: RuntimeConfig constructed fresh each cycle from pluginPrefs
-- File state: Text and image files written to disk for control page display
+- Subprocess command: `PYTHON3_PATH text2png.py <image_path> <text_path> <params_path> YES|NO classic|modern`
+- `PYTHON3_PATH` = `/Library/Frameworks/Python.framework/Versions/Current/bin/python3` (never `sys.executable`)
+- `text2png.py` dispatches to `text2png_modern.py` if `board_style == 'modern'`
+- Exit codes: 0=success, 1=file I/O error, 2=PIL error, 3=config error
+- Timeout: 10 seconds
 
-## Key Abstractions
+**Content-hash optimization**: SHA-256 of board text + parameters file. Image regeneration
+is skipped if hash matches `image_content_hash` device state (avoids redundant disk writes).
 
-**StationBoard (Darwin API response):**
-- Purpose: Represents all departures from a given station
-- Examples: `device_manager.py` line 213 accesses `board.train_services` list
-- Pattern: Navigated via getattr() for null-safety
+### Board Styles
 
-**ServiceItem (Darwin API response):**
-- Purpose: Single train service with basic info (destination, times, operator)
-- Examples: `device_manager.py` line 157-160 extracts destination_text, std, etd
-- Pattern: Short-lived objects from API, stored as device state strings
+| Style | Dimensions | File suffix | Renderer |
+|-------|-----------|-------------|----------|
+| Classic | 720×400px landscape | `{CRS1}{CRS2}timetable.png` | `text2png.py` (original) |
+| Modern | 414×variable portrait | `{CRS1}{CRS2}timetable_mobile.png` | `text2png_modern.py` |
 
-**ServiceDetails (Darwin API response):**
-- Purpose: Full service info including calling points and cancellation/delay reasons
-- Examples: `device_manager.py` line 108-113 accesses subsequent_calling_points
-- Pattern: Fetched separately for each service after main board query
+Both styles read the same `.txt` text file written by `_write_departure_board_text()`.
 
-**PluginPaths (configuration object):**
-- Purpose: Centralized path management with lazy directory creation
-- Examples: `plugin.py` line 764 `self.paths.get_parameters_file()`
-- Pattern: Immutable dataclass with convenience getters
+Output directory: user-configured `imageFilename` pref, defaulting to `~/Documents/IndigoImages/`.
 
-**ColorScheme (configuration object):**
-- Purpose: Immutable color configuration for image generation
-- Examples: `constants.py` line 76-85 defines defaults; `config.py` line 62-68 loads from prefs
-- Pattern: Passed through layers via RuntimeConfig
+## Configuration Architecture
 
-## Entry Points
+Three layers:
+1. **`PluginConfig` dataclass** (`config.py`) — mutable runtime state (debug flag, paths, station dict)
+2. **`RuntimeConfig` dataclass** (`config.py`) — snapshot of plugin prefs per polling cycle
+3. **`PluginConfiguration` Pydantic model** (`config.py`) — startup validation (optional, skipped if pydantic absent)
 
-**Plugin Startup:**
-- Location: `plugin.py:705 def startup()`
-- Triggers: Indigo framework calls when plugin enabled
-- Responsibilities: Initialize logger, load preferences, register device state changes
+**`PluginPaths` dataclass** (`config.py`) — all file paths centralized, auto-detects newest
+Indigo version folder under `~/Library/Application Support/Perceptive Automation/`.
 
-**Concurrent Thread Loop:**
-- Location: `plugin.py:745 def runConcurrentThread()`
-- Triggers: Indigo framework spawns on plugin load
-- Responsibilities: Infinite loop polling each route device at refresh_freq interval
+## Module Decomposition
 
-**Device Add/Modify Callbacks:**
-- Location: `plugin.py:536 def deviceStartComm()` and `deviceStopComm()`
-- Triggers: Indigo framework when user adds/removes/disables device
-- Responsibilities: Track active devices for polling loop
-
-**Action Callbacks:**
-- Location: `plugin.py:650-703` (sensor action handlers)
-- Triggers: Indigo UI or automation rules when user requests action
-- Responsibilities: Validate/log read-only sensor requests (no actual control)
-
-## Error Handling
-
-**Strategy:** Graceful degradation with per-service fault tolerance
-
-**Patterns:**
-
-- API Retry: Exponential backoff via tenacity decorator (darwin_api.py:47-78) — up to 3 attempts on transient errors
-- Silent Service Skip: When `_fetch_service_details()` fails, skip that train but continue with others (device_manager.py:222-224)
-- Device Skip: If device update fails (`routeUpdate()` returns False), mark device as "Awaiting update" and move to next device (plugin.py:806-811)
-- Fallback Timezone: If pytz import fails, use GMT instead of BST (text_formatter.py:31-38)
-- Graceful Dependency Handling: If pydantic or tenacity missing, validate manually or skip retry logic (plugin.py:40-56, darwin_api.py:62-67)
-
-## Cross-Cutting Concerns
-
-**Logging:** PluginLogger class at `plugin.py:74-100` writes rotating file logs to Indigo Logs directory; debug flag controls verbosity throughout
-
-**Validation:** Pydantic models in `config.py:154-241` validate API keys, paths, update frequency; device properties validated in Indigo UI via Devices.xml schema
-
-**Authentication:** Darwin API token passed via ZEEP SOAP header (nredarwin/webservice.py:52-71); no session persistence (new session per route update)
-
-**Time Handling:** All times displayed in UK timezone using pytz (text_formatter.py:20-38); Darwin API returns times as strings requiring parsing
-
-**Image Generation:** Subprocess isolation to avoid PIL/library conflicts with Indigo's embedded Python (image_generator.py:52-95); text file intermediary used for IPC
-
----
-
-*Architecture analysis: 2026-02-01*
+`plugin.py` imports from five supporting modules:
+- `config.py` — dataclasses + Pydantic models
+- `constants.py` — magic numbers, enums, color schemes
+- `darwin_api.py` — SOAP authentication and fetching
+- `device_manager.py` — state clearing, updating, calling points
+- `image_generator.py` — text file writing, subprocess dispatch, content hashing
+- `text_formatter.py` — pure functions: `getUKTime()`, `delayCalc()`, `formatSpecials()`

--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -1,250 +1,96 @@
-# Codebase Concerns
+# CONCERNS
 
-**Analysis Date:** 2026-02-01
+## Critical Bugs
+
+### `indigo.debugger()` left in `runConcurrentThread()`
+**File**: `plugin.py` line 789
+**Impact**: CRITICAL — plugin will stall waiting for a debugger to attach every time it starts.
+This call is unconditional inside the main polling loop, not guarded by any debug flag.
+
+### Two conflicting logging systems
+**Files**: `plugin.py` (`self.logger` vs `self.plugin_logger`)
+`self.logger` is the Indigo built-in; `self.plugin_logger` is the custom `PluginLogger`.
+Both are used inconsistently. In `runConcurrentThread()` there is `self.logger.info(...)` 
+alongside `self.plugin_logger.debug(...)`. Risk of log messages being silenced or duplicated.
+
+### `errorHandler` has duplicated placeholder copies
+`errorHandler` is defined at module level in `plugin.py` as the real implementation.
+Identical placeholder stubs also exist in `darwin_api.py`, `device_manager.py`, and
+`image_generator.py`. The stubs only print to stderr — they do not use the rotating
+file logger. Any call to `errorHandler` inside those modules silently skips proper logging.
 
 ## Tech Debt
 
-**Hardcoded Python Path:**
-- Issue: Python executable path is hardcoded in old codebase references but now relies on `sys.executable` in `constants.py` line 57, which could differ across environments
-- Files: `constants.py:57`, references in subprocess calls `image_generator.py:79-81`
-- Impact: May fail on systems where Python is installed in non-standard locations or when running under different Python interpreters
-- Fix approach: Already partially addressed with `sys.executable`, but document this dependency clearly and test across Python versions
+### Dependencies not bundled in `Contents/Packages/`
+zeep, lxml, requests, pytz, pydantic, tenacity, Pillow all require manual `pip install`.
+Standard Indigo packaging practice bundles them. This breaks on fresh Indigo installs
+and after Python upgrades.
 
-**Module-Level Pytz Availability Check:**
-- Issue: Global `_MODULE_FAILPYTZ` flag set at import time (line 143 in `plugin.py`) runs before plugin instantiation, making it difficult to handle gracefully if pytz import fails during plugin operation
-- Files: `plugin.py:143,226,229`, `text_formatter.py:15,18,31`
-- Impact: Plugin cannot recover from pytz import failures; timezone handling falls back to GMT only without explicit warning to user
-- Fix approach: Move pytz check into runtime configuration object and allow user to force timezone handling mode via preferences
+### `tinydb` vendored but unused
+`tinydb/` is fully bundled in `Server Plugin/` but no production code imports it.
+Dead weight that will confuse future maintainers.
 
-**Subprocess Shell Integration Dependency:**
-- Issue: Image generation relies on separate subprocess (`text2png.py`) spawned from main plugin process to avoid shared library conflicts with Indigo's embedded Python
-- Files: `image_generator.py:79-89`, `plugin.py` (historic subprocess.call usage)
-- Impact: Debugging is fragile (output logged to separate files), process lifecycle not fully managed, no timeout enforcement on subprocess
-- Fix approach: Implement subprocess timeout with `subprocess.TimeoutExpired` handling, consolidate image generation into main plugin if possible
+### Legacy global constants in `constants.py`
+```python
+STATUS_ON_TIME = TrainStatus.ON_TIME.value  # deprecated
+STATUS_CANCELLED = TrainStatus.CANCELLED.value  # deprecated
+```
+These remain "for backward compatibility" with no removal plan.
 
-**Incomplete Tenacity Error Handling:**
-- Issue: Retry decorator gracefully degrades to no-op if tenacity unavailable (lines 47-78 in `darwin_api.py`), but transient errors like timeouts are not retried in this case
-- Files: `darwin_api.py:47-78`, `plugin.py:50-56`
-- Impact: When tenacity unavailable, API calls fail immediately without retry, reducing reliability
-- Fix approach: Implement fallback retry logic using built-in retry mechanism if tenacity missing
+### Station code parsing bug in `selectStation()`
+`stationList` is built as `line[4:]` (skipping 4 chars = `CRS,` prefix), but the CSV
+format is `CRS,Station Name` — CRS codes are 3 chars + comma = 4 chars. This works
+for most codes but will silently fail for any station whose name starts differently.
+`createStationDict()` uses the same `line[4:]` offset for name extraction.
 
-## Known Bugs
+### Image generation limited to 5 trains displayed
+`constants.MAX_TRAINS_DISPLAYED = 5` while `MAX_TRAINS_TRACKED = 10`. The classic board
+renderer only renders the first 5 even though up to 10 are stored in device states.
+No current plans to reconcile this.
 
-**HTML Stripping Not Implemented:**
-- Symptoms: NRCC messages from Darwin API may contain HTML tags (noted in webservice.py line 207-208)
-- Files: `nredarwin/webservice.py:207`, `device_manager.py:88-89`
-- Trigger: When special messages are fetched from Darwin API for display on control pages
-- Workaround: User must manually clean HTML from displayed messages; `formatSpecials()` attempts cleanup but is incomplete
+### No arrivals board support
+Only departures are fetched (`include_arrivals=False` hardcoded in `_fetch_station_board()`).
 
-**Service Details Fetch May Return None:**
-- Symptoms: Calling points not displayed if service details API call fails; trains show incomplete information
-- Files: `device_manager.py:221-224`, `darwin_api.py:125-146`
-- Trigger: Transient API failures or network timeouts during `GetServiceDetails` call
-- Workaround: Retry occurs automatically with tenacity, but if max retries exceeded, calling points silently omitted
+### HTML in NRCC messages not fully stripped
+`formatSpecials()` in `text_formatter.py` removes HTML tags and some entities but uses
+a simple regex. Malformed HTML, attribute patterns like `href=`, or unusual entities
+can leak into the output text. Acknowledged in `CLAUDE.md` known limitations.
 
-**AttributeError Risk in Device State Updates:**
-- Symptoms: Plugin crashes if Darwin API response contains unexpected schema (e.g., missing optional fields)
-- Files: `device_manager.py:156-171`, `image_generator.py:112-116`
-- Trigger: Darwin API schema change or malformed response from National Rail service
-- Workaround: Extensive use of `getattr()` with defaults mitigates but not comprehensive; exception logs to stderr only
+### `runConcurrentThread()` calls `self.shutdown()` on exit
+At the end of the `while True` loop (after `StopThread` breaks it), `self.shutdown()` is
+called manually. Indigo already calls `shutdown()` — this may result in double-shutdown.
 
-## Security Considerations
+### Version checker remnants
+`plugin.py` line 465 sets `travelVersionFile = 'https://www.dropbox.com/...'` but is never
+used (the `self.updater` initialization was removed). Dead reference.
 
-**API Key Exposure in Logs:**
-- Risk: Darwin API key stored in plugin preferences and passed through function calls; risk of appearing in error logs or debug output
-- Files: `config.py:41,58,158,164`, `darwin_api.py:150`
-- Current mitigation: API key validation in config but no log sanitization; subprocess errors written to separate files outside plugin log
-- Recommendations: Add explicit log message filtering to sanitize API keys before writing to logs; review error output in `myImageErrors.txt` and `myImageOutput.txt` for key leakage
+### `validatePrefsConfigUi()` called in `__init__`
+Calling preference validation inside `__init__` is non-standard Indigo pattern. This should
+be driven by Indigo's UI callback, not the constructor.
 
-**Subprocess Command Injection Risk:**
-- Risk: File paths passed to subprocess without shell escaping; if user image path contains special characters or commands, could potentially be exploited
-- Files: `image_generator.py:79-85`
-- Current mitigation: Path objects used and converted to strings, but no shell=True so direct injection unlikely
-- Recommendations: Continue avoiding shell=True; add validation to user-provided paths that subprocess will receive
+## TODOs in Source
 
-**Environment Variable Dependency:**
-- Risk: Darwin WSDL URL and API key can fall back to environment variables if not provided (webservice.py:33-35), potentially allowing injection attacks if environment is compromised
-- Files: `nredarwin/webservice.py:33-35`
-- Current mitigation: Function parameters override environment variables
-- Recommendations: Document that environment variables are fallback only; consider removing this feature in favor of explicit parameter passing
-
-## Performance Bottlenecks
-
-**Repeated Station Code Dictionary Builds:**
-- Problem: Station dictionary loaded from file and built fresh every time user opens device configuration (createStationDict() called during validation)
-- Files: `plugin.py:446,1172-1236`
-- Cause: No caching of station codes; full file parse on each device config validation
-- Improvement path: Cache station dictionary in plugin instance during startup; refresh only on explicit user action or periodic interval
-
-**Sequential Darwin API Calls:**
-- Problem: Plugin polls each device sequentially in concurrent thread (line 784-830 in plugin.py); if Darwin API is slow, entire refresh cycle delays
-- Files: `plugin.py:804,830`
-- Cause: Single-threaded polling loop with no parallelization
-- Improvement path: Use ThreadPoolExecutor or asyncio to fetch multiple station boards concurrently; currently limited by Indigo's single-threaded model
-
-**Image Generation on Every Update:**
-- Problem: PNG image generated on every refresh cycle (even when data unchanged) if createMaps enabled
-- Files: `plugin.py:762-770`, `image_generator.py:52-89`
-- Cause: No change detection; subprocess spawned regardless of whether board data changed
-- Improvement path: Cache previous board state and only regenerate image if content differs; track modification timestamp
-
-**Station Board Row Limit:**
-- Problem: Only 10 services requested from Darwin API (DARWIN_ROW_LIMIT in constants.py:23) but max 5 displayed on images
-- Files: `constants.py:13-14,23`
-- Cause: Historical limitation; no clear reason why 10 tracked vs 5 displayed
-- Improvement path: Clarify requirements and reduce row limit if 10 not needed, or increase display count
+- `nredarwin/webservice.py` line 11: `# TODO - timeouts and error handling`
+- `nredarwin/webservice.py` line 207: `# TODO - would be nice to strip HTML from NRCC messages`
+- `nredarwin/webservice.py` line 364: `# TODO - Adhoc alerts, datetime inflators`
+- `image_generator.py` line 334: `DEBUG:` print to stderr during service hours for missing platforms
 
 ## Fragile Areas
 
-**Darwin SOAP Response Parsing:**
-- Files: `nredarwin/webservice.py` (entire file), `device_manager.py:156-171`
-- Why fragile: Uses dynamic attribute access (getattr) on ZEEP SOAP objects; any schema change from National Rail breaks parsing. Calling points extraction (lines 106-134 in device_manager.py) chains multiple getattr calls with minimal error handling
-- Safe modification: Add unit tests for SOAP response parsing with mock Darwin responses; document expected schema; consider schema validation
-- Test coverage: Integration tests exist but mock responses may not cover all API variations
+### Time parsing in `delayCalc()`
+The first-character check `scheduled_time[0] not in '012'` is fragile — a time like `23:xx`
+would pass, but an unusual Darwin response string could produce incorrect delay calculations.
 
-**Timezone Handling Fallback:**
-- Files: `plugin.py:143,226-229`, `text_formatter.py:15-31`
-- Why fragile: Pytz unavailability falls back silently to GMT; no user notification; calling code assumes timezone context always available
-- Safe modification: Make timezone handling explicit in configuration; test with and without pytz installed; add startup warning if fallback active
-- Test coverage: No test for pytz unavailability scenario
+### `text2png_modern.py` parsing relies on dash-padding
+If `_format_station_board()` changes its padding length below 3 dashes, `re.split(r'-{3,}', line)`
+in `text2png_modern.py` would fail to parse. The two renderers are coupled by this format.
 
-**Color Validation:**
-- Files: `plugin.py:575-613`
-- Why fragile: Validates colors by checking for '#' character only; allows invalid hex colors (e.g., "#ZZZ", "#12") to pass through
-- Safe modification: Use regex pattern to validate hex color format (#[0-9A-Fa-f]{3} or #[0-9A-Fa-f]{6})
-- Test coverage: Unit tests needed for color validation
+### `trainparameters.txt` written on every polling cycle
+The parameters file is overwritten at the top of each `runConcurrentThread()` loop with
+hardcoded string: `f'{colors.foreground},{colors.background},...,9,3,3,720'`. Any mid-cycle
+subprocess call reads an already-valid file, but this is not atomic.
 
-**Calling Points String Formatting:**
-- Files: `device_manager.py:97-134`, `image_generator.py:92-153`
-- Why fragile: Wraps calling points at word boundaries by finding ')' character; fails if station name format changes or contains special characters
-- Safe modification: Use proper text wrapping library (textwrap module); implement tests with various station names
-- Test coverage: No unit tests for calling points formatting
-
-## Scaling Limits
-
-**Single Route Per Device:**
-- Current capacity: One device = one origin-to-destination route; users must create multiple devices for multiple routes
-- Limit: Number of route devices limited by Indigo server performance; polling all devices in single thread
-- Scaling path: Implement device grouping or batch polling; use async/concurrent execution for multiple routes
-
-**API Rate Limiting:**
-- Current capacity: Unknown (National Rail does not publish rate limits)
-- Limit: Plugin makes continuous requests on refresh cycle; could be throttled by Darwin API
-- Scaling path: Implement request rate limiting and exponential backoff with jitter; monitor response codes for rate limit indicators
-
-**Image File Accumulation:**
-- Current capacity: One PNG per device per refresh; no cleanup of old images
-- Limit: User disk space; if refresh interval is 60s, generates 1440 images per device per day
-- Scaling path: Implement image rotation/cleanup policy; move to in-memory image buffer if possible, or use delta encoding
-
-**Concurrent Thread Workload:**
-- Current capacity: Single concurrent thread handles all polling; CPU-bound due to SOAP parsing and image generation
-- Limit: Plugin thread blocks Indigo server thread during timeouts; long refresh cycles cause lag
-- Scaling path: Implement thread pool; use non-blocking I/O for Darwin API calls; offload image generation to separate worker process
-
-## Dependencies at Risk
-
-**Zeep 4.x Dependency:**
-- Risk: Zeep is SOAP client library; not widely used in modern Python; vendor lock-in to particular SOAP schema implementation
-- Impact: If Zeep abandons SOAP support or introduces breaking changes, plugin breaks; no alternative SOAP clients in Python ecosystem are mainstream
-- Migration plan: Monitor Zeep releases; keep detailed SOAP schema documentation; consider migrating to REST API if National Rail offers one in future
-
-**Pillow (PIL) Dependency:**
-- Risk: Text2png.py uses Pillow for image generation; subprocess invocation means plugin and text2png must use compatible Pillow versions
-- Impact: Version conflicts between plugin's Indigo Python environment and text2png's environment could cause image generation failures
-- Migration plan: Version lock Pillow in requirements.txt; document compatible versions; consider migrating to lightweight drawing library
-
-**Pydantic Optional Dependency:**
-- Risk: Config validation uses Pydantic if available but gracefully degrades to no validation (lines 41-46 in plugin.py, 411-422)
-- Impact: Without Pydantic, invalid configurations not caught until runtime; users can set invalid values (e.g., negative refresh intervals)
-- Migration plan: Make Pydantic required dependency for cleaner code; alternatively, implement comprehensive validation without Pydantic
-
-**National Rail Darwin API:**
-- Risk: External service dependency; API can change schema, add rate limits, or shut down
-- Impact: Plugin becomes non-functional if Darwin API changes; no alternative data sources integrated
-- Migration plan: Monitor Darwin API documentation; implement comprehensive schema validation; document fallback options
-
-## Missing Critical Features
-
-**No Arrival Board Support:**
-- Problem: Plugin only displays departures; cannot show arriving trains
-- Blocks: Users cannot track incoming train schedules; feature request likely from users wanting to know when trains arrive
-- Priority: Medium - partially designed for in webservice.py but not exposed through plugin UI
-
-**No Historical Data:**
-- Problem: Plugin only shows current snapshot; no history of delays, cancellations, or patterns
-- Blocks: Users cannot analyze reliability trends; no reporting capabilities
-- Priority: Low - out of scope for real-time display plugin
-
-**No Mobile/Remote Access:**
-- Problem: Plugin data only accessible through Indigo control pages; no REST API or mobile app integration
-- Blocks: Users cannot check train status outside home or on mobile devices
-- Priority: High - Indigo-iOS app could consume plugin data via REST endpoint
-
-**No Custom Alerts:**
-- Problem: Plugin updates device states but no built-in alert actions (SMS, email, notifications)
-- Blocks: Users must create separate Indigo triggers for alerts; cannot configure alert thresholds easily
-- Priority: Medium - standard Indigo action pattern could be used
-
-## Test Coverage Gaps
-
-**Darwin API Response Variations:**
-- What's not tested: Real Darwin API returns many optional fields and status strings; mock tests use simplified responses
-- Files: `tests/mocks/mock_darwin.py:213`, `tests/integration/test_live_darwin_api.py`
-- Risk: Code may fail when encountering actual API responses with missing fields or unexpected values
-- Priority: High
-
-**Edge Cases in Time Parsing:**
-- What's not tested: Darwin returns times as strings like "On time", "Cancelled", "--:--", etc.; parser may fail on variations
-- Files: `text_formatter.py` (delayCalc function), `device_manager.py:156-171`
-- Risk: Malformed time values could crash time parsing or display garbled times to users
-- Priority: High
-
-**Subprocess Failures:**
-- What's not tested: Image generation subprocess can fail for many reasons (permissions, disk full, font missing, Pillow version conflict)
-- Files: `image_generator.py:79-89`
-- Risk: Subprocess errors silently logged to external files; plugin continues as if image generation succeeded
-- Priority: High
-
-**Station Code Validation:**
-- What's not tested: Invalid CRS codes (non-3-letter codes, fake codes) passed to Darwin API
-- Files: `plugin.py:469-473,491-494`
-- Risk: Darwin API returns error response that may not be handled gracefully; user gets unclear error message
-- Priority: Medium
-
-**Timezone Edge Cases:**
-- What's not tested: Daylight saving time transitions, timezones outside UK
-- Files: `text_formatter.py:15-31`
-- Risk: If pytz unavailable and DST active, times displayed in wrong timezone
-- Priority: Medium
-
-**Configuration Validation:**
-- What's not tested: Boundary conditions for refresh interval (MIN_UPDATE_FREQ_SECONDS, MAX_UPDATE_FREQ_SECONDS); invalid color codes
-- Files: `constants.py:17-19`, `plugin.py:575-613`
-- Risk: Users can set invalid configurations that cause runtime errors
-- Priority: Medium
-
-**Concurrent Thread Safety:**
-- What's not tested: Plugin preferences accessed from concurrent thread while user modifies settings in UI
-- Files: `plugin.py:757-758`
-- Risk: Race condition could cause plugin to read inconsistent preferences or crash with KeyError
-- Priority: Low - Indigo likely handles thread-safe preference access but not explicitly tested
-
-## Implementation Notes
-
-### For Tech Debt Fixes
-1. **Priority order:** API key log sanitization (security) → subprocess timeout enforcement (reliability) → station dict caching (performance)
-2. **Regression risk:** Medium - changes to error handling and subprocess management require integration testing with real Darwin API
-
-### For Bug Fixes
-1. **HTML stripping:** Implement or integrate html2text library; test with actual NRCC messages
-2. **Service details failures:** Already handled with graceful degradation; consider user notification if calling points consistently fail
-
-### For Test Coverage
-1. **Start with:** Darwin API response variations (use live API to capture real responses)
-2. **Then add:** Timezone edge cases, subprocess failures, color validation
-3. **Use:** pytest fixtures for mock Darwin responses; conftest.py already has mock infrastructure
-
----
-
-*Concerns audit: 2026-02-01*
+### Subprocess Python path hardcoded
+`PYTHON3_PATH = '/Library/Frameworks/Python.framework/Versions/Current/bin/python3'`
+If Indigo uses a different Python install location (e.g., after macOS upgrade), image
+generation silently fails with `FileNotFoundError`.

--- a/.planning/codebase/CONVENTIONS.md
+++ b/.planning/codebase/CONVENTIONS.md
@@ -1,169 +1,88 @@
-# Coding Conventions
+# CONVENTIONS
 
-**Analysis Date:** 2026-02-01
+## Python Style
 
-## Naming Patterns
+- Python 3 syntax throughout (f-strings, `pathlib.Path`, type hints, dataclasses)
+- `# coding=utf-8` header on all source files
+- Type hints used in function signatures for new/refactored code (not uniformly applied in older code)
+- `from typing import Dict, Tuple, Optional, List, Any` imports are common
+- `@dataclass` and `@dataclass(frozen=True)` used for config/color objects in `constants.py` and `config.py`
+- Enums used for train status codes: `TrainStatus` in `constants.py`
 
-**Files:**
-- Lowercase with underscores: `device_manager.py`, `text_formatter.py`, `darwin_api.py`
-- Mock files prefixed: `mock_indigo.py`, `mock_darwin.py`
-- Test files prefixed: `test_*.py`, `conftest.py`
-- Plugin main entry point: `plugin.py`
+## Module-Level Imports with Graceful Fallback
 
-**Functions:**
-- Snake case: `delayCalc()`, `routeUpdate()`, `getUKTime()`, `_fetch_station_board()`
-- Private functions prefixed with underscore: `_clear_device_states()`, `_update_station_issues_flag()`, `_process_special_messages()`
-- Descriptive verb-based names: `errorHandler()`, `createStationDict()`, `formatSpecials()`
+Optional dependencies are wrapped in try/except at module level:
 
-**Variables:**
-- Snake case: `api_key`, `darwin_url`, `station_dict`, `error_log_path`
-- Constants in ALL_CAPS: `MAX_TRAINS_TRACKED`, `DEFAULT_UPDATE_FREQ_SECONDS`, `DARWIN_WSDL_DEFAULT`
-- State dictionary keys: `stationCRS`, `destinationCRS`, `train1Dest`, `train1Est` (camelCase for device state keys)
-- Private module variables prefixed with underscore: `_MODULE_FAILPYTZ`, `_MODULE_PYPATH`
-
-**Types:**
-- Dataclasses for immutable config: `ColorScheme(frozen=True)` in `constants.py`
-- Model classes: `RuntimeConfig`, `DarwinAPIConfig`, `PluginConfig`, `PluginPaths`
-- Enum for status values: `TrainStatus` enum with `.value` access for backward compatibility
-- Service/Mock classes: `DarwinLdbSession`, `MockDevice`, `MockStationBoard`
-
-## Code Style
-
-**Formatting:**
-- Python 3 style (no `print` statements in production code, use `logger`)
-- UTF-8 encoding declared: `# coding=utf-8` at file top
-- File header comments explain module purpose
-- 120-character line length (inferred from code samples)
-
-**Linting:**
-- No explicit linting config detected (.eslintrc, .flake8, etc.)
-- Type hints used consistently: `def __init__(self, plugin_id: str, log_dir: Path, debug: bool = False)`
-- Optional/Union types explicitly annotated: `Optional[str]`, `Any`, `List`, `Dict`, `Tuple`
-
-## Import Organization
-
-**Order:**
-1. System modules: `import os, sys, time, datetime, traceback, re`
-2. Standard library with explicit imports: `from pathlib import Path`, `from typing import Dict, Tuple, Optional, List, Any`
-3. Third-party libraries with fallback handling:
-   ```python
-   try:
-       import pytz
-   except ImportError:
-       pytz = None
-       _MODULE_FAILPYTZ = True
-   ```
-4. Local imports: `import constants`, `from config import PluginConfig`, `from darwin_api import darwin_api_retry`
-
-**Path Aliases:**
-- No explicit path aliases detected; uses relative imports within plugin bundle
-- Test imports use `sys.path.insert()` to add directories: `sys.path.insert(0, str(plugin_dir))`
-
-## Error Handling
-
-**Patterns:**
-- Module-level `try/except` for optional dependencies with graceful degradation:
-  - `try: import pytz except ImportError: pass` - falls back to GMT
-  - `try: from pydantic import BaseModel except ImportError: BaseModel = None` - disables validation if unavailable
-- Function returns tuple `(success: bool, message: str)` for status reporting: `delayCalc()` returns `(has_problem, message)`
-- Explicit error logging with context via `PluginLogger` class wrapping Python's logging module
-- Exception chaining with `sys.exc_info()` capture and `traceback.print_exception()`
-
-**Logging:**
 ```python
-# Error logging with traceback:
-plugin.plugin_logger.exception(error_msg)
-plugin.plugin_logger.error(error_msg)
-
-# Fallback to print if logger unavailable:
-print(f"ERROR: {error_msg}", file=sys.stderr)
-traceback.print_exception(*exc_info, limit=2, file=sys.stderr)
+try:
+    from pydantic import BaseModel, Field, field_validator, HttpUrl
+except ImportError:
+    BaseModel = None
+    ...
 ```
+
+Code paths that use optional deps check `if BaseModel is not None:` or equivalent.
+This pattern applies to: `pydantic`, `tenacity`, `pytz`.
+
+Hard-required deps (zeep, nredarwin, functools, indigo) exit via `sys.exit(N)` if missing.
 
 ## Logging
 
-**Framework:** Python's `logging` module with `RotatingFileHandler`
+**Two parallel logging systems** — both are in use:
 
-**Patterns:**
-- Centralized logger class: `PluginLogger` wraps `logging.getLogger(f'Plugin.{plugin_id}')`
-- Methods: `.debug()`, `.info()`, `.warning()`, `.error()`, `.exception()` (passes traceback)
-- Log format: `'%(asctime)s - %(name)s - %(levelname)s - %(funcName)s:%(lineno)d - %(message)s'`
-- File rotation: 1MB max file size with 5 backup files retained
-- Debug flag controls logging level: `logging.DEBUG` if debug enabled, else `logging.INFO`
-- Logs written to: `/Library/Application Support/Perceptive Automation/Indigo [version]/Logs/UKTrains.log`
+1. **`self.logger`** (Indigo built-in, via `PluginBase`) — writes to Indigo Event Log. Used for
+   a handful of legacy calls (e.g., `self.logger.info(...)` in `runConcurrentThread()`).
 
-## Comments
+2. **`self.plugin_logger`** (custom `PluginLogger` class in `plugin.py`) — `RotatingFileHandler`
+   writing to `UKTrains.log`. Used for most new/refactored code paths.
 
-**When to Comment:**
-- Module docstrings explain purpose and scope
-- Function docstrings with Args/Returns/Raises sections (Google-style)
-- Complex logic with inline comments explaining "why" not "what"
-- Section headers like `# ========== Darwin API Functions ==========` organize code logically
+The `PluginLogger` wrapper exposes: `debug()`, `info()`, `warning()`, `error()`, `exception()`, `set_debug()`.
 
-**JSDoc/TSDoc:**
-- Not applicable (Python project)
-- Uses Python docstrings with type hints in function signatures instead
-- Example:
-  ```python
-  def delayCalc(scheduled_time: str, estimated_time: str) -> Tuple[bool, str]:
-      """Calculate delay between scheduled and estimated times.
+Debug logging is controlled by plugin pref `checkboxDebug1`. The `set_debug()` method is called
+on `startup()` and at the start of each polling cycle.
 
-      Args:
-          scheduled_time: Scheduled time string (HH:MM format or status)
-          estimated_time: Estimated time string (HH:MM format or status like "On time")
+Module-level functions (`errorHandler`, placeholder handlers in `darwin_api.py`, `device_manager.py`,
+`image_generator.py`) fall back to `print(..., file=sys.stderr)` when the plugin logger is
+not available.
 
-      Returns:
-          Tuple of (has_problem: bool, message: str)
-      """
-  ```
+## Error Handling
 
-## Function Design
+- SOAP/network errors: caught as `(WebFault, Exception)`, logged, `routeUpdate()` returns `False`
+- Missing station file: `sys.exit(1)` — hard stop
+- Missing required deps: `sys.exit(N)` with distinct codes (3..7) per dep
+- Image generation errors: caught by subprocess exit code, logged, device state updated
+- Per-service errors: isolated — one service failure does not abort remaining services
+- `logger.exception()` used for unexpected exceptions (includes full traceback)
 
-**Size:**
-- Small focused functions (30-50 lines typical)
-- Examples: `getUKTime()` (18 lines), `delayCalc()` (40 lines), `_clear_device_states()` (12 lines)
+## Device State Updates
 
-**Parameters:**
-- Use type hints for all parameters
-- Prefer dataclass objects over many primitional parameters: `RuntimeConfig` bundles 4 params
-- Optional parameters explicitly typed: `Optional[str] = None`
-- Functions accept mock-friendly objects to enable testing
+Always via `dev.updateStateOnServer(key, value=...)`. Never write to `dev.states` directly.
+All states defined in `Devices.xml` with `readonly="YES"` (plugin is the only writer).
 
-**Return Values:**
-- Explicit return types: `-> bool`, `-> str`, `-> Tuple[bool, str]`, `-> Optional[Any]`
-- Status functions return `(success: bool, message: str)` tuple for clarity
-- Device update functions return `True` on success, `False` on failure with logging for errors
+## Plugin Prefs vs Device Props
 
-## Module Design
+Critical distinction documented in `CLAUDE.md`:
+- Plugin-wide settings: `self.pluginPrefs.get(key, default)` — available only in Plugin class methods
+- Device-specific settings: `device.pluginProps.get(key, default)`
+- Module-level functions receive `plugin_prefs` as explicit parameter — never access `self`
 
-**Exports:**
-- Clear separation of concerns: `darwin_api.py` for API calls, `text_formatter.py` for text processing, `device_manager.py` for device updates
-- Public functions documented at module top with clear purpose
-- Retry decorators abstracted to module level: `@darwin_api_retry()` applied selectively
+## Path Handling
 
-**Barrel Files:**
-- Not detected; direct imports from source modules preferred
-- Example: `from darwin_api import darwin_api_retry, _fetch_station_board, _fetch_service_details, nationalRailLogin`
+All file paths use `pathlib.Path` objects. String conversion (`str(path)`) only at subprocess
+call boundaries. Directory creation via `path.mkdir(parents=True, exist_ok=True)`.
 
-**Constants Module:**
-- Centralized configuration: `constants.py` contains `MAX_TRAINS_TRACKED`, color schemes, file paths
-- Enum for status strings with backward-compatible `.value` properties
-- Dataclass for immutable configuration: `ColorScheme(frozen=True)`
+## Subprocess Calls
 
-## Configuration Management
+Always use `constants.PYTHON3_PATH` (hardcoded `/Library/Frameworks/Python.framework/Versions/Current/bin/python3`).
+Never use `sys.executable` — it points to `IndigoPluginHost3.app`.
+Use `subprocess.run(..., capture_output=True, text=True, timeout=10, check=False)`.
 
-**Approach:**
-- Dataclasses for configuration objects: `PluginConfig`, `RuntimeConfig`, `PluginPaths`
-- Pydantic models for validation when available (optional): `DarwinAPIConfig`, `UpdateConfig`, `ImageConfig`
-- Factory methods for initialization: `RuntimeConfig.from_plugin_prefs(prefs)`, `PluginPaths.initialize(plugin_path)`
-- Dictionary-based fallback for Indigo plugin preferences with explicit keys
+## Departure Board Text Format
 
-**Indigo Plugin Prefs Keys:**
-- API: `darwinAPI` (API key), `darwinSite` (WSDL URL)
-- Image: `createMaps` (bool as string "true"/"false"), `imageFilename` (path)
-- Colors: `forcolour`, `bgcolour`, `isscolour`, `cpcolour`, `ticolour` (hex strings)
-- Update: `updateFreq` (seconds as string), `checkboxDebug1` (debug flag)
+Dash-padded CSV written by `_write_departure_board_text()`:
+- Service lines: `Destination-------Platform-----Time-----Status---Operator`
+- Status lines: `Status:<message>`
+- Calling points lines: `>>> Station(HH:MM) Station(HH:MM) ...`
 
----
-
-*Convention analysis: 2026-02-01*
+Both `text2png.py` and `text2png_modern.py` parse this format.
+`text2png_modern.py` uses `re.split(r'-{3,}', line)` to split on 3+ consecutive dashes.

--- a/.planning/codebase/INTEGRATIONS.md
+++ b/.planning/codebase/INTEGRATIONS.md
@@ -1,152 +1,56 @@
-# External Integrations
+# INTEGRATIONS
 
-**Analysis Date:** 2026-02-01
+## National Rail Darwin LDB Webservice
 
-## APIs & External Services
+The only external service. Provides real-time UK train departure/arrival data via SOAP.
 
-**National Rail Darwin API:**
-- UK National Rail real-time departure and arrival information service
-  - SDK/Client: zeep>=4.2.1 (SOAP client)
-  - Endpoint: `https://lite.realtime.nationalrail.co.uk/OpenLDBWS/wsdl.aspx` (WSDL)
-  - Auth: `DARWIN_WEBSERVICE_API_KEY` environment variable (free API key from https://www.nationalrail.co.uk/developers/)
-  - API Type: SOAP webservice
-  - Key operations:
-    - `get_station_board()` - Fetch departure/arrival board for station with optional destination filtering
-    - `get_service_details()` - Fetch calling points and additional details for a specific train service
-  - Usage: `nredarwin.webservice.DarwinLdbSession` in `UKTrains.indigoPlugin/Contents/Server Plugin/nredarwin/webservice.py`
+- **WSDL endpoint**: `https://lite.realtime.nationalrail.co.uk/OpenLDBWS/wsdl.aspx`
+  (configurable in plugin prefs, stored as `darwinSite`)
+- **Authentication**: API key header injection via zeep's `BearerKeyPlugin`
+  (handled in `nredarwin/webservice.py`, key stored as plugin pref `darwinAPI`)
+- **Protocol**: SOAP over HTTPS
+- **Namespace**: `http://thalesgroup.com/RTTI/2010-11-01/ldb/commontypes`
 
-## Data Storage
+### API Key
 
-**Databases:**
-- None configured for production use
-- TinyDB (embedded) - Bundled locally in `UKTrains.indigoPlugin/Contents/Server Plugin/tinydb/` for potential local JSON storage
-  - Connection: File-based (not currently in active use)
-  - Client: Custom TinyDB implementation (v3 fork)
+Free registration at National Rail developer portal. Stored in Indigo plugin preferences —
+not in any dotenv or config file. No secrets should be committed to the repo (see `.env.example`).
 
-**File Storage:**
-- Local filesystem only
-- Departure board images: `~/Documents/IndigoImages/` (configurable via `PluginConfig.xml`)
-- Plugin logs: `~/Library/Application Support/Perceptive Automation/Indigo [VERSION]/Logs/`
-- Station codes: `UKTrains.indigoPlugin/Contents/Server Plugin/stationCodes.txt`
-- Parameters: `UKTrains.indigoPlugin/Contents/Server Plugin/trainparameters.txt`
+### Methods Used
 
-**Caching:**
-- None - Real-time data fetched on each poll cycle (configurable interval, default 60 seconds)
+| Method | Darwin Operation | Wrapper |
+|--------|-----------------|---------|
+| Get departures board (all destinations) | `get_station_board(crs, row_limit, True, False)` | `_fetch_station_board()` in `darwin_api.py` |
+| Get departures board (filtered by destination) | `get_station_board(crs, row_limit, True, False, dest_crs)` | `_fetch_station_board()` |
+| Get individual service details (calling points) | `get_service_details(service_id)` | `_fetch_service_details()` in `darwin_api.py` |
 
-## Authentication & Identity
+### Session Management
 
-**Auth Provider:**
-- Custom/Manual - Darwin API key required
-  - Implementation: Token-based SOAP header authentication
-  - Token header format: `<AccessToken><TokenValue>[API_KEY]</TokenValue></AccessToken>`
-  - Code: `UKTrains.indigoPlugin/Contents/Server Plugin/nredarwin/webservice.py:54-71` (SOAP header construction)
-  - Configured via plugin settings: `PluginConfig.xml`
+`nredarwin/webservice.py` `DarwinLdbSession` wraps zeep `Client`. Session is created
+per polling cycle (not persistent) via `nationalRailLogin()` in `darwin_api.py`.
 
-## Monitoring & Observability
+### Station Codes
 
-**Error Tracking:**
-- None (no external error tracking)
-- Manual logging to local files
+CRS (Computer Reservation System) 3-letter codes (e.g., `WAT` = London Waterloo).
+Full list in `UKTrains.indigoPlugin/Contents/Server Plugin/stationCodes.txt`
+(format: `CRS,Station Name`, ~2700+ entries). Special value `ALL` means all destinations.
 
-**Logs:**
-- Approach: Rotating file handler with size-based rotation (1MB max, 5 backups)
-- Log file: `UKTrains.log` in Indigo Logs directory
-- Code: `UKTrains.indigoPlugin/Contents/Server Plugin/plugin.py:69-95` (PluginLogger class)
-- Also logs to stderr for subprocess output
-- Debug flag in `PluginConfig.xml` controls verbosity
+### Error Handling
 
-## CI/CD & Deployment
+- SOAP faults (`zeep.exceptions.Fault`) trigger retry via tenacity decorator
+- Up to 3 retries with exponential backoff (1s, 2s, 4s) for station board
+- Up to 2 retries for service details
+- After all retries exhausted, `routeUpdate()` returns `False` and the device is
+  marked inactive for that polling cycle
 
-**Hosting:**
-- Local macOS machine (runs within Indigo home automation system)
-- Plugin distributed as `.indigoPlugin` bundle (macOS application bundle)
+### Retry Decorator
 
-**CI Pipeline:**
-- None (no external CI service configured)
-- Manual testing via pytest in development environment
+`darwin_api_retry(max_attempts)` in `darwin_api.py` — wraps tenacity. Falls back to
+identity decorator if tenacity is not installed.
 
-**Installation:**
-- Copy `UKTrains.indigoPlugin` bundle to `/Library/Application Support/Perceptive Automation/Indigo [VERSION]/Plugins/`
-- Enable in Indigo UI: Plugins → Manage Plugins
+## No Other External Services
 
-## Environment Configuration
-
-**Required env vars (Development/Testing):**
-- `DARWIN_WEBSERVICE_API_KEY` - Darwin API key (required to function)
-- `DARWIN_WEBSERVICE_WSDL` - Darwin WSDL URL (optional, has default)
-
-**Required env vars (Production/Plugin Runtime):**
-- Configured via Indigo plugin preferences UI (`PluginConfig.xml`)
-- No direct environment variable requirement in production
-
-**Secrets location:**
-- Development: `.env` file (git-ignored, see `.gitignore`)
-- Production: Indigo plugin preferences database (encrypted by Indigo)
-- Plugin security: API key stored in `plugin_prefs['darwinAPI']`
-
-## Webhooks & Callbacks
-
-**Incoming:**
-- None
-
-**Outgoing:**
-- None
-
-## API Integration Details
-
-### Darwin API Implementation
-
-**Location:** `UKTrains.indigoPlugin/Contents/Server Plugin/`
-
-**Main Integration Files:**
-- `darwin_api.py` - Wrapper functions with retry logic
-  - `nationalRailLogin()` - Authenticate and create DarwinLdbSession
-  - `_fetch_station_board()` - Fetch departures with exponential backoff retry
-  - `_fetch_service_details()` - Fetch calling points with retry
-  - Decorator: `@darwin_api_retry()` handles transient failures (WebFault, ConnectionError, TimeoutError)
-
-- `nredarwin/webservice.py` - Low-level SOAP client
-  - `DarwinLdbSession` class wraps zeep SOAP client
-  - Uses requests.Session for HTTP with 5-second timeout
-  - zeep HistoryPlugin for debugging SOAP calls
-  - SOAP authentication via AccessToken header
-
-**Retry Strategy:**
-- Uses tenacity library with exponential backoff
-- Station board: max 3 attempts, 1-10 seconds between retries
-- Service details: max 2 attempts, 1-10 seconds between retries
-- Retries on: WebFault (SOAP), ConnectionError, TimeoutError
-- Failures logged but don't stop plugin (graceful degradation)
-
-**Error Handling:**
-- Darwin API failures return False from `routeUpdate()`, skip update on next cycle
-- SOAP timeouts are expected and handled gracefully
-- Missing dependencies cause immediate plugin exit with logging
-- Code: `UKTrains.indigoPlugin/Contents/Server Plugin/darwin_api.py:47-78` (retry decorator)
-
-### Network Configuration
-
-**SSL/TLS:**
-- Enabled by default in zeep transport
-- Code: `nredarwin/webservice.py:39` (`session.verify = True`)
-
-**Timeouts:**
-- Default 5 seconds for both connection and operation timeouts
-- Configurable in `DarwinLdbSession.__init__()` via `timeout` parameter
-- Code: `nredarwin/webservice.py:40` (transport timeout)
-
-### Data Formats
-
-**Darwin API Responses:**
-- SOAP XML (zeep parses to Python objects)
-- Station board returns: List of train services with times, delays, calling points
-- Service details returns: Calling points with actual/estimated times
-
-**Departure Board Output:**
-- Text format: `[START_CRS][END_CRS]departureBoard.txt`
-- PNG format: `[START_CRS][END_CRS]timetable.png` (subprocess-generated)
-- Location: `~/Documents/IndigoImages/` (configurable)
-
----
-
-*Integration audit: 2026-02-01*
+- No version-check service (references to `updater` and `dropbox` URL were removed)
+- No push notifications
+- No cloud relay
+- All image output is local filesystem writes

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -1,90 +1,57 @@
-# Technology Stack
+# STACK
 
-**Analysis Date:** 2026-02-01
+## Language & Runtime
 
-## Languages
+- **Python 3.10+** (Indigo 2023+ requirement)
+- Interpreter: `/Library/Frameworks/Python.framework/Versions/Current/bin/python3`
+- Plugin host: `IndigoPluginHost3.app` (Indigo's wrapper — NOT a valid subprocess target)
+- Indigo Server API version: `3.0` (from `Info.plist`)
+- IWS API version: `1.0.0`
 
-**Primary:**
-- Python 3.10+ - Main plugin implementation and Darwin API integration
-- XML - Device, action, and UI configuration (`Devices.xml`, `Actions.xml`, `PluginConfig.xml`, `MenuItems.xml`)
+## Info.plist Metadata
 
-**Secondary:**
-- Plist (XML) - Plugin metadata and configuration (`Info.plist`)
+File: `UKTrains.indigoPlugin/Contents/Info.plist`
 
-## Runtime
+| Key | Value |
+|-----|-------|
+| `PluginVersion` | `2026.0.4` |
+| `CFBundleDisplayName` | `UK Trains` |
+| `CFBundleIdentifier` | `com.simons-plugins.UKTrains` |
+| `CFBundleVersion` | `1.0.1` |
+| `ServerApiVersion` | `3.0` |
+| `GithubUser` | `simons-plugins` |
+| `GithubRepo` | `UKTrains` |
 
-**Environment:**
-- macOS (Monterey+)
-- Indigo 2023.2+ (home automation platform)
-- Python 3.10+ via Indigo's embedded Python environment: `/Library/Frameworks/Python.framework/Versions/Current/bin/python3`
+## Production Dependencies
 
-**Package Manager:**
-- pip
-- Lockfile: requirements.txt in `UKTrains.indigoPlugin/Contents/Server Plugin/requirements.txt`
+Declared in `UKTrains.indigoPlugin/Contents/Server Plugin/requirements.txt`.
+Must be installed manually into Indigo's Python environment — there is no `Contents/Packages/` bundle.
 
-## Frameworks
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `zeep` | `>=4.2.1` | Modern SOAP client for Darwin webservice |
+| `lxml` | `>=4.9.0` | XML processing (required by zeep) |
+| `requests` | `>=2.31.0` | HTTP transport (required by zeep) |
+| `pytz` | `==2023.2` | UK timezone / BST handling (optional, falls back to GMT) |
+| `pydantic` | `==2.5.3` | Plugin config validation (optional, gracefully absent) |
+| `tenacity` | `==8.2.3` | Retry logic with exponential backoff (optional, gracefully absent) |
+| `Pillow` | `>=10.0.0` | PNG image generation via subprocess |
 
-**Core:**
-- Indigo API 3.0 - Plugin lifecycle, device state management, logging
-- zeep>=4.2.1 - SOAP client for Darwin webservice (replaces deprecated SUDS library)
+## Bundled Libraries (in Server Plugin directory)
 
-**Testing:**
-- pytest==7.4.3 - Test runner
-- pytest-mock==3.12.0 - Mock fixtures for testing
-- pytest-cov==4.1.0 - Code coverage reporting
-- freezegun==1.4.0 - Time mocking for time-dependent tests
-- mock==5.1.0 - Test doubles
+- `nredarwin/` — vendored fork of Robert Clake's nredarwin SOAP wrapper, modified to use zeep
+- `tinydb/` — vendored TinyDB library (present but not actively used in main code paths)
 
-**Build/Dev:**
-- Pillow>=10.0.0 - Image generation for departure board PNG creation (subprocess-based)
+## Test Dependencies
 
-## Key Dependencies
+Declared in `tests/requirements-test.txt`:
+- `pytest==7.4.3`, `pytest-mock==3.12.0`, `pytest-cov==4.1.0`
+- `freezegun==1.4.0` (time mocking)
+- `mock==5.1.0`
+- `coverage[toml]==7.4.0`
 
-**Critical:**
-- zeep>=4.2.1 - SOAP client for National Rail Darwin API (required, replaces old SUDS library)
-- lxml>=4.9.0 - XML processing required by zeep
-- requests>=2.31.0 - HTTP transport required by zeep
+## Install Command
 
-**Infrastructure:**
-- pytz==2023.2 - Timezone handling for UK time (BST/GMT) display; gracefully falls back to GMT if unavailable
-- pydantic==2.5.3 - Configuration validation for Darwin API settings and plugin preferences
-- tenacity==8.2.3 - Retry logic with exponential backoff for transient Darwin API failures
-- Pillow>=10.0.0 - PIL image generation for departure board PNG output
-
-**Data Storage:**
-- TinyDB (bundled) - Embedded in plugin at `UKTrains.indigoPlugin/Contents/Server Plugin/tinydb/` for local JSON-based data persistence
-
-## Configuration
-
-**Environment:**
-- `.env` file (development only) - For Darwin API credentials during local testing
-- Environment variables:
-  - `DARWIN_WEBSERVICE_API_KEY` - Darwin API authentication key
-  - `DARWIN_WEBSERVICE_WSDL` - Darwin WSDL endpoint URL (defaults to `https://lite.realtime.nationalrail.co.uk/OpenLDBWS/wsdl.aspx`)
-
-**Build:**
-- `Info.plist` - Plugin metadata (version 2025.1.3, API version 3.0)
-- `PluginConfig.xml` - Plugin preferences UI for Darwin API key, update frequency, image colors
-- Devices.xml - "trainTimetable" device type with state definitions for 10 trains per route
-
-**Runtime Config Files:**
-- `trainparameters.txt` - Color and font parameters for image generation subprocess
-- `stationCodes.txt` - CRS (Computer Reservation System) station codes for validation
-
-## Platform Requirements
-
-**Development:**
-- macOS Monterey or later
-- Xcode command-line tools (for building)
-- Python 3.10+ development headers
-- Valid Darwin API key from National Rail (free at https://www.nationalrail.co.uk/developers/)
-
-**Production:**
-- macOS Monterey or later
-- Indigo 2023.2+ running on macOS
-- Network connection to Darwin API (realtime.nationalrail.co.uk)
-- Subprocess spawning capability (for image generation via PIL)
-
----
-
-*Stack analysis: 2026-02-01*
+```bash
+/Library/Frameworks/Python.framework/Versions/Current/bin/python3 -m pip install -r requirements.txt
+```

--- a/.planning/codebase/STRUCTURE.md
+++ b/.planning/codebase/STRUCTURE.md
@@ -1,254 +1,99 @@
-# Codebase Structure
+# STRUCTURE
 
-**Analysis Date:** 2026-02-01
-
-## Directory Layout
+## Repository Root
 
 ```
-UK-Trains/                                          # Repository root
-├── UKTrains.indigoPlugin/                          # Indigo plugin bundle
-│   ├── Contents/
-│   │   ├── Info.plist                              # Plugin metadata (bundle ID, version)
-│   │   └── Server Plugin/
-│   │       ├── plugin.py                           # Main plugin class & lifecycle
-│   │       ├── config.py                           # Configuration dataclasses
-│   │       ├── constants.py                        # Magic numbers & enums
-│   │       ├── darwin_api.py                       # Darwin API wrapper with retry logic
-│   │       ├── device_manager.py                   # Device state updates
-│   │       ├── image_generator.py                  # PNG generation coordination
-│   │       ├── text_formatter.py                   # Pure utility functions
-│   │       ├── text2png.py                         # Subprocess for PIL image generation
-│   │       ├── nredarwin/                          # SOAP client library
-│   │       │   ├── __init__.py
-│   │       │   └── webservice.py                   # DarwinLdbSession ZEEP wrapper
-│   │       ├── tinydb/                             # Bundled TinyDB library
-│   │       ├── Devices.xml                         # Device type definitions (trainTimetable)
-│   │       ├── Actions.xml                         # Action definitions
-│   │       ├── MenuItems.xml                       # Plugin menu items
-│   │       ├── PluginConfig.xml                    # Plugin settings UI
-│   │       ├── stationCodes.txt                    # CRS code to station name lookup
-│   │       ├── BoardFonts/                         # Fonts for image generation
-│   │       └── trainparameters.txt                 # Color/layout config for image gen
-│
-├── tests/                                          # Test suite
-│   ├── conftest.py                                 # pytest fixtures & configuration
-│   ├── mocks/
-│   │   ├── mock_darwin.py                          # Mock Darwin API for testing
-│   │   └── mock_indigo.py                          # Mock Indigo framework objects
-│   ├── unit/
-│   │   ├── test_text_formatting.py                 # Text utility tests
-│   │   └── test_time_calculations.py               # Time/delay calculation tests
-│   ├── integration/
-│   │   ├── test_live_darwin_api.py                 # Live API tests
-│   │   └── test_route_update.py                    # Full route update flow tests
-│   └── fixtures/
-│       └── darwin_responses/                       # SOAP response samples
-│
-├── .planning/                                      # GSD planning documents
-│   └── codebase/
-│       ├── ARCHITECTURE.md                         # This architecture document
-│       ├── STRUCTURE.md                            # This structure document
-│       ├── CONVENTIONS.md                          # Coding patterns & style
-│       ├── TESTING.md                              # Test framework & patterns
-│       ├── STACK.md                                # Technology stack
-│       ├── INTEGRATIONS.md                         # External dependencies
-│       └── CONCERNS.md                             # Technical debt & issues
-│
-├── .github/workflows/                              # CI/CD pipelines
-├── README.md                                       # Project overview
-├── CLAUDE.md                                       # Development guidance
-├── BUGFIX_SUMMARY.md                               # Recent fixes
-├── DIAGNOSIS_SUMMARY.md                            # Debugging logs
-├── TESTING_GUIDE.md                                # Manual test procedures
-└── requirements.txt                                # Python dependencies
+UK-Trains/
+├── UKTrains.indigoPlugin/          # Indigo plugin bundle
+├── tests/                          # Test suite (pytest)
+├── CLAUDE.md                       # Project-specific Claude Code guidance
+├── README.md
+├── TESTING_GUIDE.md
+├── RUN_LIVE_TEST.md
+├── test_darwin_live.py             # Ad-hoc live API test script (root level)
+├── inspect_wsdl.py                 # Dev utility to inspect Darwin WSDL
+├── .env                            # API key (not committed)
+├── .env.example                    # Template for .env
+└── license.txt
 ```
 
-## Directory Purposes
+## Plugin Bundle
 
-**UKTrains.indigoPlugin/Contents/Server Plugin:**
-- Purpose: Main plugin logic and Indigo integration
-- Contains: Plugin class, API wrappers, device management, image generation
-- Key files: `plugin.py` (entry point), `config.py` (settings), `darwin_api.py` (API layer)
+```
+UKTrains.indigoPlugin/
+└── Contents/
+    ├── Info.plist                  # Plugin metadata (CFBundleIdentifier, PluginVersion)
+    └── Server Plugin/              # All Python source and assets
+        ├── plugin.py               # Main Plugin class + routeUpdate() + PluginLogger
+        ├── config.py               # PluginConfig, PluginPaths, RuntimeConfig, Pydantic models
+        ├── constants.py            # Magic numbers, TrainStatus enum, ColorScheme dataclasses
+        ├── darwin_api.py           # nationalRailLogin(), _fetch_station_board(), _fetch_service_details()
+        ├── device_manager.py       # Device state management functions
+        ├── image_generator.py      # PNG generation coordination + content hashing
+        ├── text_formatter.py       # Pure text utilities: getUKTime(), delayCalc(), formatSpecials()
+        ├── text2png.py             # Classic board renderer (720×400, Dot Matrix font, green-on-black)
+        ├── text2png_modern.py      # Modern board renderer (414×variable, card-based, WCAG AA colors)
+        ├── Devices.xml             # trainTimetable device type definition
+        ├── Actions.xml             # Plugin action definitions
+        ├── MenuItems.xml           # Plugin menu items
+        ├── PluginConfig.xml        # Plugin preferences UI
+        ├── stationCodes.txt        # CRS→Station Name lookup (~2700+ stations, CSV format)
+        ├── trainparameters.txt     # Runtime-written color/font config for image renderer
+        ├── requirements.txt        # Production pip dependencies
+        ├── __init__.py
+        ├── BoardFonts/             # Font assets for classic board renderer
+        │   └── MFonts/             # Dot Matrix and other monospace fonts
+        ├── nredarwin/              # Vendored Darwin SOAP wrapper
+        │   ├── __init__.py
+        │   └── webservice.py       # DarwinLdbSession class
+        ├── tinydb/                 # Vendored TinyDB (present, not actively used)
+        ├── myImageErrors.txt       # Legacy image subprocess error log (superseded by RotatingFileHandler)
+        ├── myImageOutput.txt       # Legacy image subprocess output log
+        └── test_zeep_connection.py # Ad-hoc dev script for testing zeep connection
+```
 
-**tests/unit:**
-- Purpose: Pure function unit tests without Indigo or Darwin dependencies
-- Contains: Text formatter tests, time calculation tests
-- Key files: `test_text_formatting.py`, `test_time_calculations.py`
+## Tests
 
-**tests/integration:**
-- Purpose: Full flow tests with mock or real Darwin API
-- Contains: Route update flow tests, live API connection tests
-- Key files: `test_route_update.py`, `test_live_darwin_api.py`
+```
+tests/
+├── conftest.py                     # Session fixtures, mock injection, helpers
+├── pytest.ini                      # Pytest config, markers, pythonpath
+├── requirements-test.txt           # Test-only pip dependencies
+├── run_tests.sh                    # Shell script to run test suite
+├── __init__.py
+├── unit/
+│   ├── test_text_formatting.py     # Tests for delayCalc(), formatSpecials(), getUKTime()
+│   └── test_time_calculations.py   # Time arithmetic unit tests
+├── integration/
+│   ├── test_route_update.py        # routeUpdate() integration tests (mocked Darwin)
+│   └── test_live_darwin_api.py     # Live API tests (marked live_api, skipped by default)
+├── mocks/
+│   ├── mock_indigo.py              # MockIndigo module (injected as sys.modules['indigo'])
+│   └── mock_darwin.py              # Factory functions for mock Darwin sessions/services
+└── fixtures/
+    └── darwin_responses/           # Static response fixtures for tests
+```
 
-**tests/mocks:**
-- Purpose: Test doubles for Indigo framework and Darwin API
-- Contains: Mock objects matching real API interfaces
-- Key files: `mock_indigo.py` (device/state mock), `mock_darwin.py` (SOAP response mock)
+## Output Files (runtime, not in repo)
 
-**nredarwin/:**
-- Purpose: SOAP client library for Darwin webservice
-- Contains: Zeep-based client with header building and service binding
-- Key files: `webservice.py` (DarwinLdbSession class)
+Written to the user-configured image directory (default `~/Documents/IndigoImages/`):
 
-**tinydb/:**
-- Purpose: Bundled embedded JSON database library
-- Contains: TinyDB implementation (currently unused in active code)
-- Key files: Middleware and database implementations
+```
+<image_dir>/
+├── {CRS1}{CRS2}departureBoard.txt  # Departure board text data (e.g., WALWATdepartureBoard.txt)
+├── {CRS1}{CRS2}timetable.png       # Classic departure board image
+└── {CRS1}{CRS2}timetable_mobile.png  # Modern departure board image (when enabled)
+```
 
-**BoardFonts/:**
-- Purpose: Font files for departure board image generation
-- Contains: Dot Matrix and other monospace fonts for board display
-- Key files: Accessible via `PluginPaths.fonts_dir` path
-
-## Key File Locations
-
-**Entry Points:**
-- `UKTrains.indigoPlugin/Contents/Server Plugin/plugin.py`: Main Plugin class (line 659+), extends indigo.PluginBase
-- `UKTrains.indigoPlugin/Contents/Server Plugin/plugin.py:745`: `runConcurrentThread()` — infinite loop entry point
-
-**Configuration:**
-- `UKTrains.indigoPlugin/Contents/Info.plist`: Bundle identifier, plugin version, author
-- `UKTrains.indigoPlugin/Contents/Server Plugin/PluginConfig.xml`: Plugin settings dialog UI
-- `UKTrains.indigoPlugin/Contents/Server Plugin/config.py`: RuntimeConfig, PluginConfig, PluginPaths dataclasses
-
-**Core Logic:**
-- `UKTrains.indigoPlugin/Contents/Server Plugin/plugin.py:281`: `routeUpdate()` — main business logic orchestrator
-- `UKTrains.indigoPlugin/Contents/Server Plugin/device_manager.py:185`: `_process_train_services()` — train processing loop
-- `UKTrains.indigoPlugin/Contents/Server Plugin/darwin_api.py:150`: `nationalRailLogin()` — SOAP authentication
-
-**Device Definitions:**
-- `UKTrains.indigoPlugin/Contents/Server Plugin/Devices.xml`: Device type "trainTimetable" with 10 train states
-- `UKTrains.indigoPlugin/Contents/Server Plugin/Actions.xml`: Custom action definitions
-
-**Testing:**
-- `tests/conftest.py`: pytest configuration with fixtures
-- `tests/mocks/mock_indigo.py`: Mock Indigo device/state objects
-- `tests/mocks/mock_darwin.py`: Mock Darwin SOAP responses
-
-**Data Files:**
-- `UKTrains.indigoPlugin/Contents/Server Plugin/stationCodes.txt`: Station CRS code ↔ name mapping
-- `UKTrains.indigoPlugin/Contents/Server Plugin/trainparameters.txt`: Image generation parameters (colors, fonts)
-- Generated files: `{CRS}{CRS}departureBoard.txt`, `{CRS}{CRS}timetable.png` (in user Documents or configured path)
+Log file: `~/Library/Application Support/Perceptive Automation/Indigo <version>/Logs/UKTrains.log`
+(RotatingFileHandler, 1 MB max, 5 backups)
 
 ## Naming Conventions
 
-**Files:**
-- `plugin.py`: Main plugin class (Indigo standard)
-- `*_manager.py`: Manager classes (device_manager.py, not device.py)
-- `*_api.py`: API wrapper modules (darwin_api.py)
-- `*_formatter.py`: Pure utility modules (text_formatter.py)
-- `*_generator.py`: Generators/builders (image_generator.py)
-- `test_*.py`: Test files (pytest convention)
-- `mock_*.py`: Mock objects for testing
-- `conftest.py`: pytest configuration
-
-**Functions:**
-- `routeUpdate()`: Main orchestrator (camelCase, public)
-- `_process_train_services()`: Internal helper (leading underscore prefix, camelCase)
-- `_fetch_station_board()`: API wrappers (leading underscore, camelCase)
-- `delayCalc()`: Pure utilities (camelCase, no prefix)
-- `getUKTime()`: Accessor functions (get/set prefix, camelCase)
-
-**Variables:**
-- `stationStartCrs`, `stationEndCrs`: CRS codes (camelCase, descriptive)
-- `dev`: Indigo device object (abbreviated due to frequent use)
-- `station_dict`, `station_codes`: Dictionaries (snake_case when from config)
-- `MAX_TRAINS_TRACKED`: Constants (UPPER_SNAKE_CASE)
-- `departures_found`: Boolean flags (snake_case, descriptive)
-
-**Types/Classes:**
-- `Plugin(indigo.PluginBase)`: Main plugin class
-- `RuntimeConfig`: Configuration dataclass
-- `PluginPaths`: Path management dataclass
-- `DarwinLdbSession`: SOAP client wrapper
-- `PluginLogger`: Custom logger wrapper
-- `TrainStatus`: Enum for status constants
-
-**Device States:**
-- `train{N}Dest`, `train{N}Sch`, `train{N}Est`: Per-train states (1-10 trains)
-- `stationIssues`: Boolean flag (no train number prefix)
-- `deviceActive`: Device enable/disable flag
-- `deviceStatus`: Human-readable status string
-
-## Where to Add New Code
-
-**New Feature (route logic/Darwin API):**
-- Primary code: `UKTrains.indigoPlugin/Contents/Server Plugin/plugin.py` or new module
-- If new API call: Add wrapper in `darwin_api.py` with retry decorator
-- If new device state: Add definition in `Devices.xml`, update in `device_manager.py`
-- Tests: `tests/integration/test_route_update.py` for flow tests
-
-**New Component/Module:**
-- Implementation: `UKTrains.indigoPlugin/Contents/Server Plugin/{feature}_manager.py` or `{feature}_api.py`
-- Import in: `plugin.py` main file (see import block at line 232-254)
-- Tests: Create `tests/unit/test_{feature}.py` for unit tests
-
-**Utilities:**
-- Pure functions: `text_formatter.py` (already contains time, delay, formatting utilities)
-- Config: `config.py` (add new dataclass or Pydantic model)
-- Constants: `constants.py` (add to enums or dataclasses)
-
-**Tests:**
-- Unit tests: `tests/unit/test_*.py` for pure functions
-- Integration tests: `tests/integration/test_*.py` for full flows
-- Fixtures: `tests/fixtures/darwin_responses/` for SOAP response samples
-- Mocks: `tests/mocks/mock_*.py` for test doubles
-
-## Special Directories
-
-**BoardFonts/:**
-- Purpose: Font files for image generation
-- Generated: No (bundled with plugin)
-- Committed: Yes
-- Access: Via `config.PluginPaths.fonts_dir`
-
-**tinydb/:**
-- Purpose: Embedded JSON database library
-- Generated: No (bundled dependency)
-- Committed: Yes
-- Usage: Currently not used in active code paths
-
-**Generated Image Output (configurable):**
-- Purpose: PNG departure board images and text intermediaries
-- Default location: `~/Documents/IndigoImages/`
-- User-configurable: Via PluginConfig.xml `imageFilename` setting
-- Lifetime: Overwritten on each route update cycle
-- Not committed: These are runtime artifacts
-
-**.planning/codebase/:**
-- Purpose: GSD codebase mapping documents (architecture, structure, conventions, etc.)
-- Generated: By GSD mapping command
-- Committed: Yes (tracking design decisions and patterns)
-
-## Import Organization
-
-**Standard pattern in plugin.py (lines 30-70):**
-1. System modules: `os`, `sys`, `time`, `datetime`, `traceback`, `re`, `subprocess`, `dataclasses`, `pathlib`, `typing`, `logging`
-2. Try/except optional: `pydantic`, `tenacity`, `indigo` (required)
-3. Local module: `import constants`
-4. Conditional: `import pytz`
-
-**Module import pattern in device_manager.py:**
-1. System: `typing`
-2. Local config: `import constants`
-3. Local functions: `from text_formatter import ...`
-4. Local modules: `from darwin_api import ...`
-
-**Path aliases:**
-- None used; all imports relative to plugin module directory
-- Absolute paths used for file system operations via `Path()` objects
-
-## Path Resolution
-
-All paths centralized in `config.PluginPaths`:
-
-- Plugin bundle: Detected at runtime via `_MODULE_PYPATH` (plugin.py:230)
-- Station codes: `plugin_root / 'stationCodes.txt'`
-- Fonts: `plugin_root / 'BoardFonts' / 'MFonts'`
-- Image output: User-configured via `imageFilename` pref, defaults to `~/Documents/IndigoImages/`
-- Logs: Dynamic Indigo version detection (e.g., `~/Library/Application Support/Perceptive Automation/Indigo 2024.1/Logs/`)
-- Parameters: `plugin_root / 'trainparameters.txt'`
-
----
-
-*Structure analysis: 2026-02-01*
+- Plugin bundle: `UKTrains.indigoPlugin` (PascalCase, `.indigoPlugin` extension)
+- Python modules: `snake_case.py`
+- Device type ID: `trainTimetable` (camelCase, used in `indigo.devices.iter('self.trainTimetable')`)
+- Device states: camelCase (e.g., `train1Dest`, `stationIssues`, `deviceActive`)
+- Plugin pref keys: camelCase (e.g., `darwinAPI`, `checkboxDebug1`, `generateClassicBoard`)
+- CRS codes: UPPERCASE 3-letter (e.g., `WAT`, `PAD`, `BRI`)
+- Image file pattern: `{STARTCRS}{ENDCRS}timetable.png` (e.g., `WALWATtimetable.png`)

--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -1,329 +1,78 @@
-# Testing Patterns
+# TESTING
 
-**Analysis Date:** 2026-02-01
+## Framework
 
-## Test Framework
-
-**Runner:**
-- pytest 7.4.3
+- **pytest** `7.4.3` with `pytest-mock`, `pytest-cov`, `freezegun`, `mock`
 - Config: `tests/pytest.ini`
+- Run from `tests/` directory: `bash run_tests.sh` or `pytest`
 
-**Assertion Library:**
-- pytest's built-in assertions (no special assertion library)
+## Test Layout
 
-**Run Commands:**
-```bash
-cd tests
-pytest                           # Run all tests
-pytest -m unit                   # Run unit tests only
-pytest -m integration            # Run integration tests only
-pytest -m live_api               # Run REAL Darwin API tests (skipped by default)
-pytest -v                        # Verbose output
-pytest --co                      # Collect tests without running
-pytest -m "not live_api"         # Run everything except live API tests
-```
-
-## Test File Organization
-
-**Location:**
-- Separate from source code: `tests/` directory at project root
-- Mirror structure not enforced; grouped by type instead
-
-**Naming:**
-- Test files: `test_*.py` pattern
-- Test classes: `Test*` pattern
-- Test functions: `test_*` pattern
-- Fixtures: `conftest.py` at `tests/` directory level
-
-**Structure:**
 ```
 tests/
-├── conftest.py                    # Global fixtures and mocking setup
-├── pytest.ini                     # Pytest configuration
-├── fixtures/                      # Test data (unused currently)
-│   └── __init__.py
-├── mocks/                         # Mock implementations
-│   ├── __init__.py
-│   ├── mock_indigo.py             # Indigo API mocks
-│   └── mock_darwin.py             # Darwin API mocks
-├── unit/                          # Pure function tests
-│   ├── __init__.py
-│   ├── test_text_formatting.py    # formatSpecials() function tests
-│   └── test_time_calculations.py  # delayCalc() function tests
-└── integration/                   # Full workflow tests with mocks
-    ├── __init__.py
-    ├── test_live_darwin_api.py    # Tests with REAL Darwin API
-    └── test_route_update.py       # routeUpdate() workflow tests
+├── unit/                   # Pure function tests (no Indigo, no network)
+│   ├── test_text_formatting.py   — delayCalc(), formatSpecials(), getUKTime()
+│   └── test_time_calculations.py — time arithmetic helpers
+├── integration/            # Component tests with mocked dependencies
+│   ├── test_route_update.py      — routeUpdate() with mock Darwin sessions
+│   └── test_live_darwin_api.py   — marked live_api (skipped by default)
+├── mocks/
+│   ├── mock_indigo.py      — MockIndigo class (injected as sys.modules['indigo'])
+│   └── mock_darwin.py      — Factory functions for mock station boards and services
+└── fixtures/
+    └── darwin_responses/   — Static response fixtures
 ```
 
-## Test Structure
+## Indigo Mock Strategy
 
-**Suite Organization:**
-```python
-@pytest.mark.unit
-class TestDelayCalc:
-    """Test cases for delayCalc function"""
+`conftest.py` injects `MockIndigo` into `sys.modules['indigo']` **before** importing
+`plugin.py`. This must happen at module level (not inside fixtures) because `plugin.py`
+imports `indigo` at the top of the file.
 
-    def test_on_time_string(self):
-        """Test when service is exactly on time (string 'On time')"""
-        has_problem, message = plugin.delayCalc("14:30", "On time")
-        assert has_problem is False
-        assert message == "On time"
-```
+The mock provides: `PluginBase`, `kStateImageSel`, `devices.iter()`, `server.log()`,
+`Dict`, and other Indigo API surface needed by the plugin.
 
-**Patterns:**
-- Classes group related test methods for organization
-- Docstrings document individual test purpose
-- Class-level marker (`@pytest.mark.unit`) applied to all methods
-- No setup/teardown methods observed; fixtures used instead
+`create_mock_device()` in `mock_indigo.py` creates a device with configurable `pluginProps`,
+`states`, `enabled`, `configured` flags, and a `_state_updates` list for assertions.
 
-**Fixtures:**
-- Session-scoped: `mock_indigo_module()` - must run first for import ordering
-- Function-scoped: `mock_device()`, `mock_darwin_normal()`, `mock_darwin_delays()` - created fresh per test
-- Parametrized tests use `@pytest.mark.parametrize` decorator
+## Darwin Mock Strategy
 
-```python
-@pytest.mark.parametrize("scheduled,estimated,expected_problem,expected_msg", [
-    ("10:00", "10:00", False, "On Time"),
-    ("10:00", "10:05", True, "5 mins late"),
-    ("10:00", "Cancelled", True, "Cancelled"),
-])
-def test_common_scenarios(self, scheduled, estimated, expected_problem, expected_msg):
-    has_problem, message = plugin.delayCalc(scheduled, estimated)
-    assert has_problem == expected_problem
-    assert message == expected_msg
-```
+`mock_darwin.py` provides:
+- `create_mock_darwin_session(scenario)` — factory for scenarios: `normal`, `delays`,
+  `cancellation`, `mixed`, `empty`
+- `create_on_time_service()`, `create_delayed_service()`, `create_cancelled_service()`
+- `create_station_board_paddington()` — fixed station board fixture
 
-## Mocking
+## Pytest Markers
 
-**Framework:** `unittest.mock` (Python standard library)
+| Marker | Meaning |
+|--------|---------|
+| `unit` | Pure function tests, no I/O |
+| `integration` | Uses mock Darwin + Indigo |
+| `api` | Darwin API tests (mocked) |
+| `slow` | Long-running tests |
+| `live_api` | Makes real Darwin API calls — **skipped by default** |
 
-**Patterns:**
-- **Module-level mocking (CRITICAL):** `conftest.py` injects mock indigo before plugin import:
-  ```python
-  from mocks.mock_indigo import MockIndigo
-  mock_indigo_instance = MockIndigo()
-  sys.modules['indigo'] = mock_indigo_instance  # Before plugin imports
-  ```
-- **Fixture-based:** `@pytest.fixture` provides pre-configured mocks
-- **Patch-based:** `@patch('plugin.DarwinLdbSession', return_value=mock_darwin_normal)` for function replacement
-
-**Mock Objects:**
-- `MockDevice`: Indigo device with state tracking
-  ```python
-  class MockDevice:
-      def __init__(self, device_id=12345, name="Test Device", ...):
-          self.states = {...}
-          self._state_updates = []  # Tracks all state changes for assertions
-
-      def updateStateOnServer(self, key, value):
-          self.states[key] = value
-          self._state_updates.append({'key': key, 'value': value})
-  ```
-- `MockStationBoard`, `MockServiceItem`, `MockCallingPoint`: Darwin API response objects
-- `MockPluginBase`, `MockServer`, `MockDict`: Indigo API infrastructure mocks
-
-**What to Mock:**
-- External APIs: Darwin SOAP webservice (expensive, non-deterministic)
-- Indigo plugin infrastructure: `indigo.PluginBase`, device state management
-- File system operations: image output paths, log directories
-- Time-dependent functions: `time.time()`, `time.strftime()` for reproducible tests
-
-**What NOT to Mock:**
-- Pure calculation functions: `delayCalc()`, `formatSpecials()` - test directly
-- String manipulation: test actual formatting output
-- Configuration parsing: validate actual config classes work correctly
-- Constants and enums: use real values for semantic verification
-
-## Fixtures and Factories
-
-**Test Data:**
-```python
-@pytest.fixture
-def mock_device():
-    """Fixture that provides a mock Indigo device with default configuration."""
-    return create_mock_device(
-        device_id=12345,
-        name="Test UK Trains Device",
-        enabled=True,
-        pluginProps={
-            'darwinAPI': 'test_api_key_12345',
-            'stationImage': True,
-            'updateFreq': 60,
-        },
-        states={
-            'stationCRS': 'PAD',
-            'destinationCRS': 'BRI',
-            'stationLong': '',
-        }
-    )
-
-@pytest.fixture
-def mock_darwin_normal():
-    """Fixture providing a Darwin session with normal (on-time) services."""
-    return create_mock_darwin_session(scenario="normal")
-
-@pytest.fixture
-def mock_darwin_delays():
-    """Fixture providing a Darwin session with delayed services."""
-    return create_mock_darwin_session(scenario="delays")
-```
-
-**Factory Functions:**
-- Located in `tests/mocks/mock_darwin.py` and `tests/mocks/mock_indigo.py`
-- Named with `create_*` pattern: `create_mock_device()`, `create_mock_darwin_session()`, `create_on_time_service()`
-- Support scenarios: "normal", "delays", "cancellation", "mixed", "empty"
-- Return configured objects ready for immediate use
-
-**Location:**
-- Test fixtures: `tests/conftest.py`
-- Mock factories: `tests/mocks/mock_indigo.py`, `tests/mocks/mock_darwin.py`
-- Sample services: `create_on_time_service()`, `create_delayed_service()`, `create_cancelled_service()`
+To run live API tests: `pytest -m live_api` (requires valid Darwin API key).
 
 ## Coverage
 
-**Requirements:** No explicit coverage target enforced
-
-**View Coverage:**
+`pytest-cov` configured. Run with:
 ```bash
-pytest --cov=../UKTrains.indigoPlugin/Contents/Server\ Plugin --cov-report=html
-# or
-coverage run -m pytest
-coverage report
-coverage html
+pytest --cov=. --cov-report=html
 ```
 
-## Test Types
+## Test Helper Assertions
 
-**Unit Tests:**
-- Scope: Pure functions with no external dependencies
-- Location: `tests/unit/`
-- Examples:
-  - `test_text_formatting.py`: Tests `formatSpecials()` - HTML removal, whitespace handling, URL cleaning
-  - `test_time_calculations.py`: Tests `delayCalc()` - time parsing, delay calculation, edge cases (midnight crossing, null values)
-- Approach: Direct function calls with simple assert statements
-- 30+ test cases covering normal paths, edge cases, parametrized scenarios
+`conftest.py` adds two helpers to the `pytest` namespace:
+- `pytest.assert_state_updated(device, key, expected_value)` — asserts a specific state was updated
+- `pytest.assert_state_contains(device, key, substring)` — asserts state contains substring
 
-**Integration Tests:**
-- Scope: Full workflows with mocked dependencies
-- Location: `tests/integration/`
-- Examples:
-  - `test_route_update.py`: Tests `routeUpdate()` with mocked Darwin API responses
-  - Mock Darwin sessions injected: on-time, delayed, cancelled, mixed scenarios
-  - Assertions verify device state updates occur correctly
-- Approach: Patch external dependencies, verify full function behavior and side effects
+## Notable Gaps
 
-**E2E Tests:**
-- Framework: Not used for automated CI
-- Manual alternative: `test_darwin_live.py` at project root makes REAL Darwin API calls
-- Skipped by default; enabled with `pytest -m live_api` and `DARWIN_API_KEY` env var
-- Purpose: Verify mock responses match real API behavior before production
-
-## Common Patterns
-
-**Async Testing:**
-Not applicable (Python 3 synchronous code; Indigo plugin runs in concurrent thread managed by framework)
-
-**Error Testing:**
-```python
-def test_cancelled_service(self):
-    """Test when service is cancelled"""
-    has_problem, message = plugin.delayCalc("14:30", "Cancelled")
-    assert has_problem is True
-    assert message == "Cancelled"
-
-def test_null_est_time(self):
-    """Test with null/None estimated time"""
-    has_problem, message = plugin.delayCalc("14:30", None)
-    assert has_problem is True
-    assert message == "Delayed"
-```
-
-**Assertion Helpers:**
-Custom helpers injected in `conftest.py` for device state assertions:
-```python
-def assert_state_updated(device, key, expected_value):
-    """Helper to assert that a device state was updated with a specific value."""
-    updates = [u for u in device._state_updates if u['key'] == key]
-    assert len(updates) > 0, f"State '{key}' was never updated"
-    assert updates[-1]['value'] == expected_value
-
-pytest.assert_state_updated = assert_state_updated
-```
-
-Usage in tests:
-```python
-def test_successful_route_update_on_time_trains(self, mock_device, ...):
-    result = plugin.routeUpdate(mock_device, api_key, network_url, paths)
-    assert result is True
-    assert len(mock_device._state_updates) > 0
-    station_updates = [u for u in mock_device._state_updates if u['key'] == 'stationLong']
-    assert station_updates[0]['value'] == "London Paddington"
-```
-
-## Test Markers
-
-**Available:**
-- `@pytest.mark.unit` - Pure function tests
-- `@pytest.mark.integration` - Workflow tests with mocks
-- `@pytest.mark.api` - Tests interacting with Darwin API (mocked)
-- `@pytest.mark.slow` - Tests that take longer to run
-- `@pytest.mark.live_api` - Tests making REAL Darwin API calls (skipped by default)
-
-**Usage:**
-```python
-@pytest.mark.unit
-class TestDelayCalc:
-    def test_on_time_string(self):
-        ...
-
-@pytest.mark.integration
-class TestRouteUpdateIntegration:
-    def test_successful_route_update_on_time_trains(self):
-        ...
-
-@pytest.mark.live_api
-def test_can_connect_to_darwin():
-    # Only runs with: pytest -m live_api
-    ...
-```
-
-## Pytest Configuration
-
-**File:** `tests/pytest.ini`
-
-**Key Settings:**
-```ini
-[pytest]
-# Test discovery
-python_files = test_*.py
-python_classes = Test*
-python_functions = test_*
-
-# Paths
-testpaths = .
-pythonpath = ../UKTrains.indigoPlugin/Contents/Server Plugin
-
-# Output
-addopts = --verbose --strict-markers
-
-# Markers
-markers =
-    unit: Unit tests for pure functions
-    integration: Integration tests with mocked dependencies
-    api: Tests that interact with Darwin API (mocked)
-    slow: Tests that take longer to run
-    live_api: Tests that make REAL calls to Darwin API (skipped by default)
-
-# Logging
-log_cli = true
-log_cli_level = INFO
-log_cli_format = %(asctime)s [%(levelname)8s] %(message)s
-
-# Exclusions
-norecursedirs = .git __pycache__ *.egg-info
-```
-
----
-
-*Testing analysis: 2026-02-01*
+- No tests for `image_generator.py` subprocess dispatch (would require Pillow + filesystem)
+- No tests for `config.py` Pydantic validation paths
+- No tests for `text2png.py` or `text2png_modern.py` rendering (visual output only)
+- Live API tests exist but require manual key setup and are excluded from CI
+- CLAUDE.md states "No automated test suite exists" — this is outdated; the suite in `tests/`
+  is real but may not be wired to CI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,33 @@
 # CLAUDE.md
 
+> **Part of the [Indigo workspace](../CLAUDE.md)** — see root for cross-project map, standards, and tooling.
+
+## Project Identity
+
+- **Name**: UK-Trains (UK National Rail Darwin)
+- **Type**: Indigo plugin
+- **Shortcut**: `trains` / `UK trains`
+- **GitHub**: https://github.com/simons-plugins/indigo-UKTrains
+- **Language**: Python 3
+
+## Role in the workspace
+
+Indigo plugin integrating the UK National Rail Darwin SOAP API for real-time train departure and arrival information, with departure board image generation.
+
+## Related projects
+
+Standalone — no sibling dependencies in this workspace.
+
+## Standards
+
+Inherits workspace standards from [root CLAUDE.md](../CLAUDE.md#common-standards-apply-to-every-project-unless-its-claudemd-overrides). Key points for this project:
+
+- **Version bump per PR**: `Info.plist` `PluginVersion`
+- **Testing**: pytest
+- **Merge**: GitHub PR only, never `--admin`, never squash, wait for CI green, wait for user go-ahead.
+
+---
+
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## 🔧 Development Tools
@@ -12,9 +40,7 @@ The `/indigo` skill provides:
 - API reference and troubleshooting guides
 - Pattern matching for common plugin tasks
 
-To access: Type `/indigo` in Claude Code to load the Indigo development skill.
-
-See: [../Indigo-skill/README.md](../Indigo-skill/README.md) for installation and usage.
+To access: Type `/indigo:dev` in Claude Code to load the Indigo development skill. The source of those commands lives in [`../indigo-claude-plugin/`](../indigo-claude-plugin/).
 
 ## Project Overview
 

--- a/UKTrains.indigoPlugin/Contents/Info.plist
+++ b/UKTrains.indigoPlugin/Contents/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>PluginVersion</key>
-	<string>2026.0.4</string>
+	<string>2026.0.5</string>
 	<key>ServerApiVersion</key>
 	<string>3.0</string>
 	<key>IwsApiVersion</key>


### PR DESCRIPTION
## Summary
- Refresh `.planning/codebase/` map (ARCHITECTURE, CONCERNS, CONVENTIONS, INTEGRATIONS, STACK, STRUCTURE, TESTING) — net −824 lines, condensed and current.
- Add standard Indigo workspace header to `CLAUDE.md` (Project Identity, Role, Related projects, Standards inheritance) to match the rest of the workspace.
- Bump `PluginVersion` to `2026.0.5` to satisfy version-check.

Docs-only — no code changes.

## Test plan
- [x] CI version-check passes
- [x] No runtime code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)