### PR TITLE
fix: bump pydantic for Python 3.13 (Indigo 2025.2)

### DIFF
--- a/UKTrains.indigoPlugin/Contents/Info.plist
+++ b/UKTrains.indigoPlugin/Contents/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>PluginVersion</key>
-	<string>2026.0.5</string>
+	<string>2026.0.6</string>
 	<key>ServerApiVersion</key>
 	<string>3.0</string>
 	<key>IwsApiVersion</key>

--- a/UKTrains.indigoPlugin/Contents/Server Plugin/requirements.txt
+++ b/UKTrains.indigoPlugin/Contents/Server Plugin/requirements.txt
@@ -2,6 +2,6 @@ zeep>=4.2.1                # Modern SOAP client (replaces SUDS)
 lxml>=4.9.0                # Required by zeep for XML processing
 requests>=2.31.0           # Required by zeep for HTTP transport
 pytz==2023.2
-pydantic==2.5.3
+pydantic>=2.10.0,<3        # 2.10+ ships pydantic-core with Python 3.13 support
 tenacity==8.2.3
 Pillow>=10.0.0             # Used by text2png.py subprocess for image generation


### PR DESCRIPTION
## Summary

- Bumps `pydantic==2.5.3` → `pydantic>=2.10.0,<3` to restore plugin
  startup under Indigo 2025.2 / Python 3.13.
- Bumps `PluginVersion` 2026.0.5 → 2026.0.6.

## What broke

Post-upgrade on jarvis, the plugin closed at startup. Event log shows
`pydantic-core 2.14.6` (transitively pinned by pydantic 2.5.3) failing
to build its wheel under Python 3.13:

```
TypeError: ForwardRef._evaluate() missing 1 required keyword-only argument: 'recursive_guard'
   ... at generate_self_schema.py
```

`ForwardRef._evaluate()` gained a required `recursive_guard` kwarg in
Python 3.13; `pydantic-core 2.14.6`'s build script predates that.

Because Indigo's requirements installer rolls back atomically when any
package fails, `zeep` was also never installed — leading to the
secondary symptom `No module named 'zeep'` at
`nredarwin/webservice.py:1`.

## Fix

`pydantic >=2.10.0` uses `pydantic-core 2.27.x`, which is 3.13-clean.
The plugin's pydantic surface (`BaseModel`, `Field`, `field_validator`,
`HttpUrl` in `config.py:12` and `plugin.py:41`) is API-stable across
2.5 → 2.10+, so this is a non-breaking bump.

## Test plan

- [x] Static review: pydantic 2.5 → 2.10+ uses identical public API
      surface for the imports the plugin uses
- [ ] Reinstall plugin on jarvis (Indigo 2025.2 / Python 3.13)
- [ ] Verify plugin starts cleanly (no `requirements.txt` errors,
      no `No module named 'zeep'`)
- [ ] Verify a route device updates with live Darwin data after
      restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)