### PR TITLE
fix: resolve Indigo log paths via getInstallFolderPath()

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,7 +250,7 @@ No automated test suite exists. Testing is manual:
 
 ### Debugging
 - Enable debug mode in plugin configuration ([PluginConfig.xml:129](UKTrains.indigoPlugin/Contents/Server%20Plugin/PluginConfig.xml#L129))
-- Debug logs written to `/Library/Application Support/Perceptive Automation/Indigo 2023.2/Logs/NationRailErrors.log`
+- Plugin log (`UKTrains.log`) is written to Indigo's `Logs/` folder, resolved at runtime via `indigo.server.getInstallFolderPath()` so it stays correct across Indigo version upgrades.
 - Global `nationalDebug` flag controls verbose logging throughout codebase
 
 ## Important Implementation Details

--- a/UKTrains.indigoPlugin/Contents/Info.plist
+++ b/UKTrains.indigoPlugin/Contents/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>PluginVersion</key>
-	<string>2026.0.6</string>
+	<string>2026.0.7</string>
 	<key>ServerApiVersion</key>
 	<string>3.0</string>
 	<key>IwsApiVersion</key>

--- a/UKTrains.indigoPlugin/Contents/Server Plugin/config.py
+++ b/UKTrains.indigoPlugin/Contents/Server Plugin/config.py
@@ -28,7 +28,6 @@ class PluginConfig:
 	debug: bool
 	plugin_path: Path
 	station_dict: Dict[str, str]
-	error_log_path: Path
 	pytz_available: bool
 
 
@@ -106,19 +105,11 @@ class PluginPaths:
 		# Ensure image output directory exists
 		image_output.mkdir(parents=True, exist_ok=True)
 
-		# Log directory - find the current Indigo version dynamically
-		perceptive_dir = Path.home() / 'Library' / 'Application Support' / 'Perceptive Automation'
-
-		# Look for Indigo folders (e.g., "Indigo 2023.2", "Indigo 2024.1", etc.)
-		indigo_folders = sorted([d for d in perceptive_dir.glob('Indigo *') if d.is_dir()], reverse=True)
-
-		if indigo_folders:
-			# Use the most recent version folder
-			log_dir = indigo_folders[0] / 'Logs'
-		else:
-			# Fallback to generic Indigo folder if version-specific not found
-			log_dir = perceptive_dir / 'Indigo' / 'Logs'
-
+		# Log directory: ask Indigo for its install folder rather than guessing.
+		# Older code probed `~/Library/Application Support/Perceptive Automation`,
+		# but the real install lives under system `/Library`, not the user home.
+		import indigo  # available at plugin runtime
+		log_dir = Path(indigo.server.getInstallFolderPath()) / 'Logs'
 		log_dir.mkdir(parents=True, exist_ok=True)
 
 		return cls(

--- a/UKTrains.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/UKTrains.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -456,7 +456,6 @@ class Plugin(indigo.PluginBase):
 			debug=pluginPrefs.get('checkboxDebug1', False),
 			plugin_path=Path(_MODULE_PYPATH),
 			station_dict={},
-			error_log_path=Path('/Library/Application Support/Perceptive Automation/Indigo 2023.2/Logs/NationRailErrors.log'),
 			pytz_available=not _MODULE_FAILPYTZ
 		)
 
@@ -785,7 +784,6 @@ class Plugin(indigo.PluginBase):
 
 		self.logger.info('New Log:'+str(time.strftime(time.asctime()))+'\n')
 
-		logTimeNextReset = time.time()+int(3600)
 		indigo.debugger()
 		while True:
 			# Load configuration once per loop using RuntimeConfig
@@ -806,15 +804,6 @@ class Plugin(indigo.PluginBase):
 
 			# Note: Update checker functionality removed - self.updater was never initialized
 			# If update checking is needed in the future, initialize self.updater in __init__
-
-			# Reset the log?
-			if logTimeNextReset<time.time():
-				with open(self.config.error_log_path, 'w') as f:
-					f.write('#'*80+'\n')
-					f.write('Log reset:'+str(time.strftime(time.asctime()))+'\n')
-					f.write('#'*80+'\n')
-				logReset = False
-				logTimeNextReset = time.time()+int(3600)
 
 			for dev in indigo.devices.iter('self.trainTimetable'):
 				# Refresh each of the timeTable route devices in turn

--- a/tests/mocks/mock_indigo.py
+++ b/tests/mocks/mock_indigo.py
@@ -80,6 +80,9 @@ class MockServer:
         self.getPlugin = Mock(return_value=MagicMock(
             pluginFolderPath='/test/path'
         ))
+        # Mirror indigo.server.getInstallFolderPath() so PluginPaths.initialize
+        # can resolve a log directory in tests without touching the real FS.
+        self.getInstallFolderPath = Mock(return_value='/tmp/test_indigo_install')
 
 
 class MockDict(dict):


### PR DESCRIPTION
## Summary

Two hardcoded-path bugs causing the plugin to write to or look for
files in the wrong place on any Indigo install other than 2023.2.

Bumps `PluginVersion` 2026.0.6 → 2026.0.7.

## What broke

### 1. `NationRailErrors.log` hourly rotation (the user-reported Feb traceback)

`plugin.py:459` initialised `error_log_path` to a hardcoded path that
included the literal string **`Indigo 2023.2`**. Inside
`runConcurrentThread`, an hourly block tried to truncate-and-write a
3-line "Log reset:" header to that path. On any other Indigo version
(e.g. jarvis on 2025.2) the directory doesn't exist:

```
File "plugin.py", line 807, in runConcurrentThread
type: [Errno 2] No such file or directory:
'/Library/Application Support/Perceptive Automation/Indigo 2023.2/Logs/NationRailErrors.log'
```

While investigating, the file turned out to be **write-only** — nothing
ever read it. The companion `self.errorLog(...)` call at `plugin.py:770`
references a method that doesn't exist anywhere in the codebase
(would `AttributeError` if reached). The whole rotation is dead code.

**Fix:** delete the dead rotation block, the `error_log_path` config
field, and the now-unused `logTimeNextReset` local. Net diff: -11
lines from `plugin.py`.

### 2. `PluginPaths.log_dir` resolved to the wrong directory tree

`config.py:110` was doing:

```python
perceptive_dir = Path.home() / 'Library' / 'Application Support' / 'Perceptive Automation'
indigo_folders = sorted([d for d in perceptive_dir.glob('Indigo *') ...])
```

`Path.home()` is the *user* home (`/Users/simon`), but Indigo installs
to the *system* `/Library`. The glob always returned empty, the
`else` fallback fired, and `mkdir(parents=True, exist_ok=True)`
silently created a parallel directory tree under `~/Library/` —
where the plugin's own `UKTrains.log` then went. Indigo's real
`Logs/` folder was never written to.

**Fix:** replace the home-directory glob with
`Path(indigo.server.getInstallFolderPath()) / 'Logs'` — the canonical
IOM way; no version-string parsing, no guessing.

## Test plan

- [x] `py_compile` clean for `plugin.py` and `config.py`
- [x] `pytest`: 52 passed, 14 skipped, 16 failed under Python 3.13.9
      — the same 16 failures present on `main` (unrelated casing/HTML
      drift in `text_formatting`/`time_calculations`); no regressions
      introduced by this change
- [x] Mocked `getInstallFolderPath` in `tests/mocks/mock_indigo.py` so
      `PluginPaths.initialize()` can be exercised in tests without
      hitting the real FS
- [ ] Deploy to jarvis (Indigo 2025.2 / Python 3.13)
- [ ] Confirm `Started plugin "UK Trains 2026.0.7"` followed by
      `runConcurrentThread` running cleanly past the next hour mark
      (no `FileNotFoundError` from the (now-deleted) rotation block)
- [ ] Confirm `UKTrains.log` lands in
      `/Library/Application Support/Perceptive Automation/Indigo 2025.2/Logs/`
      (not in `~/Library/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)