### PR TITLE
docs: point new users at Rail Data Marketplace for Darwin keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The UK Trains plugin connects your Indigo home automation system to the UK Natio
 
 - **Indigo 2023.2 or later** (macOS)
 - **Python 3.10+** (included with Indigo 2023+)
-- **Darwin API Key** (free registration at [National Rail Developers Portal](https://www.nationalrail.co.uk/developers/))
+- **Darwin API Key** (free registration via the [Rail Data Marketplace](https://raildata.org.uk/))
 
 ## Installation
 
@@ -35,11 +35,15 @@ The UK Trains plugin connects your Indigo home automation system to the UK Natio
 
 ### Getting a Darwin API Key
 
-1. Visit [https://www.nationalrail.co.uk/developers/](https://www.nationalrail.co.uk/developers/)
-2. Click "Register" and create an account
-3. Log in and navigate to "My Account" → "API Keys"
-4. Request a new API key for "Darwin LDB (Live Departure Boards)"
-5. Copy the key and paste it into the plugin configuration
+National Rail moved API key issuance to the **Rail Data Marketplace** (raildata.org.uk). The legacy OpenLDBWS registration page is no longer available — new keys are only issued via the marketplace, but the SOAP service and token format are unchanged so this plugin works without modification.
+
+1. Visit [https://raildata.org.uk/](https://raildata.org.uk/) and create an account
+2. Search for the product **"Live Departure Board Web Service (LDBWS) - Public"** (free, "Open by default")
+3. Subscribe to it and accept the licence terms
+4. From your dashboard → **My Subscriptions**, copy the API key issued for that product
+5. Paste it into the plugin's **Darwin API Key** field
+
+Existing users with a legacy OpenLDBWS token do not need to re-register — your existing key continues to work.
 
 ## Configuration
 
@@ -148,7 +152,7 @@ Display on iPads, dashboards, or control pages using Indigo's control page image
 ### Plugin won't start
 
 - Check **Indigo → Event Log** for error messages
-- Verify Darwin API key is valid (test at [Darwin API Documentation](https://lite.realtime.nationalrail.co.uk/OpenLDBWS/))
+- Verify Darwin API key is valid via your [Rail Data Marketplace](https://raildata.org.uk/) dashboard
 - Ensure Indigo 2023.2+ is installed
 
 ### No train data showing
@@ -156,7 +160,7 @@ Display on iPads, dashboards, or control pages using Indigo's control page image
 - Verify station CRS codes are correct (3 letters, uppercase)
 - Check if station has services at current time (some stations have limited hours)
 - Look for error messages in Indigo Event Log
-- Test API key at National Rail developer portal
+- Test API key from your Rail Data Marketplace subscription page
 
 ### Delays showing incorrectly
 
@@ -233,7 +237,7 @@ This plugin is provided as-is for use with Indigo home automation. Darwin API us
 
 - **Indigo Forums**: [Plugin Support Thread](https://forums.indigodomo.com/)
 - **GitHub Issues**: [Report bugs and request features](https://github.com/simons-plugins/indigo-UKTrains/issues)
-- **Darwin API Support**: [National Rail Developer Portal](https://www.nationalrail.co.uk/developers/)
+- **Darwin API Support**: [Rail Data Marketplace](https://raildata.org.uk/) — host of the LDBWS Public product
 
 ---
 

--- a/UKTrains.indigoPlugin/Contents/Info.plist
+++ b/UKTrains.indigoPlugin/Contents/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>PluginVersion</key>
-	<string>2026.0.7</string>
+	<string>2026.0.8</string>
 	<key>ServerApiVersion</key>
 	<string>3.0</string>
 	<key>IwsApiVersion</key>

--- a/UKTrains.indigoPlugin/Contents/Server Plugin/PluginConfig.xml
+++ b/UKTrains.indigoPlugin/Contents/Server Plugin/PluginConfig.xml
@@ -12,11 +12,11 @@
            type="label"
            fontSize="small"
            fontColor="blue">
-        <Label>You need to have a unique Network Rail API key and enter it here.  Check the manual or forum for details</Label>
+        <Label>You need a free Darwin API key. Subscribe to "Live Departure Board Web Service (LDBWS) - Public" at https://raildata.org.uk/ and paste the key below. (Existing OpenLDBWS keys still work.)</Label>
     </Field>
     <Field id="darwinAPI" type="textfield" defaultValue="NO KEY ENTERED">
         <Label>What is your API Key?:</Label>
-        <Description>Enter your API key - you can get one for free from Network Rail (see forum)?</Description>
+        <Description>Free key issued at https://raildata.org.uk/ — search for the "Live Departure Board Web Service (LDBWS) - Public" product and subscribe. The token is delivered via email and shown on your dashboard.</Description>
     </Field>
     <Field id="darwinSite" type="textfield" defaultValue="https://lite.realtime.nationalrail.co.uk/OpenLDBWS/wsdl.aspx">
         <Label>National Rail access site (do not change unless requested):</Label>


### PR DESCRIPTION
## Summary
- National Rail closed the standalone OpenLDBWS registration page. The README's current walkthrough (`nationalrail.co.uk/developers/` → "Register" → "API Keys" → "Darwin LDB") no longer exists; new users hit a dead end.
- Per [`nationalrail.co.uk/developers/darwin-data-feeds/`](https://www.nationalrail.co.uk/developers/darwin-data-feeds/), the only current path is the [Rail Data Marketplace](https://raildata.org.uk/) → product **"Live Departure Board Web Service (LDBWS) - Public"** (free).
- Token shape is unchanged (SOAP header value), so the plugin code, default WSDL URL, and existing user keys all keep working — this is doc/copy only.

## Changes
- `README.md`: rewrite **Getting a Darwin API Key** section, fix prerequisite line, troubleshooting links, and the Support reference.
- `PluginConfig.xml`: replace "Network Rail / see forum" copy with explicit raildata.org.uk product instructions.
- `Info.plist`: bump `PluginVersion` 2026.0.7 → 2026.0.8 (patch — docs only).

## Test plan
- [x] No code changes — existing test suite unaffected
- [ ] CI: `check-version` and `pytest` go green
- [ ] Spot-check rendered README on the PR diff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API key provisioning guidance to reference the Rail Data Marketplace.
  * Added detailed instructions for obtaining Darwin API keys through the Rail Data Marketplace.
  * Updated troubleshooting section with API key validation steps.
  * Existing legacy API keys remain fully compatible.

* **Chores**
  * Version bumped to 2026.0.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->