### PR TITLE
ci: align workflows with canonical templates

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -17,23 +17,23 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Determine plugin name
-        id: get_plugin_name
+      - name: Determine plugin bundle
+        id: get_plugin
         run: |
-          PLUGIN_BUNDLE=$(find . -maxdepth 1 -iname "*.indigoPlugin" -type d | head -1)
-          if [ -z "$PLUGIN_BUNDLE" ]; then
+          PLUGIN_BUNDLE_PATH=$(find . -maxdepth 1 -iname "*.indigoPlugin" -type d | head -1)
+          if [ -z "$PLUGIN_BUNDLE_PATH" ]; then
             echo "Error: No .indigoPlugin directory found in repository root." >&2
             exit 1
           fi
-          PLUGIN_NAME=$(basename "$PLUGIN_BUNDLE" .indigoPlugin)
-          echo "plugin_name=$PLUGIN_NAME" >> $GITHUB_OUTPUT
-          echo "Detected plugin name: $PLUGIN_NAME"
+          PLUGIN_BUNDLE=$(basename "$PLUGIN_BUNDLE_PATH")
+          echo "plugin_bundle=$PLUGIN_BUNDLE" >> $GITHUB_OUTPUT
+          echo "Detected plugin bundle: $PLUGIN_BUNDLE"
 
       - name: Extract version from Info.plist
         id: get_version
         run: |
-          PLUGIN_NAME="${{ steps.get_plugin_name.outputs.plugin_name }}"
-          VERSION=$(grep -A1 '<key>PluginVersion</key>' "${PLUGIN_NAME}.indigoPlugin/Contents/Info.plist" | grep '<string>' | sed 's/.*<string>\(.*\)<\/string>.*/\1/')
+          PLUGIN_BUNDLE="${{ steps.get_plugin.outputs.plugin_bundle }}"
+          VERSION=$(grep -A1 '<key>PluginVersion</key>' "${PLUGIN_BUNDLE}/Contents/Info.plist" | grep '<string>' | sed 's/.*<string>\(.*\)<\/string>.*/\1/')
           if [ -z "$VERSION" ]; then
             echo "Error: Could not extract PluginVersion from Info.plist." >&2
             exit 1
@@ -56,8 +56,8 @@ jobs:
       - name: Create plugin bundle zip
         if: steps.check_release.outputs.exists == 'false'
         run: |
-          PLUGIN_NAME="${{ steps.get_plugin_name.outputs.plugin_name }}"
-          zip -r "${PLUGIN_NAME}.indigoPlugin.zip" "${PLUGIN_NAME}.indigoPlugin" \
+          PLUGIN_BUNDLE="${{ steps.get_plugin.outputs.plugin_bundle }}"
+          zip -r "${PLUGIN_BUNDLE}.zip" "${PLUGIN_BUNDLE}" \
             -x "*.pyc" \
             -x "*/__pycache__" \
             -x "*/__pycache__/*" \
@@ -67,7 +67,7 @@ jobs:
             -x "*/.idea/*" \
             -x "*.bbproject" \
             -x "*.bbproject/*"
-          echo "Created ${PLUGIN_NAME}.indigoPlugin.zip"
+          echo "Created ${PLUGIN_BUNDLE}.zip"
 
       - name: Create GitHub Release
         if: steps.check_release.outputs.exists == 'false'
@@ -78,4 +78,4 @@ jobs:
           generate_release_notes: true
           draft: false
           prerelease: false
-          files: ${{ steps.get_plugin_name.outputs.plugin_name }}.indigoPlugin.zip
+          files: ${{ steps.get_plugin.outputs.plugin_bundle }}.zip

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -17,10 +17,27 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Determine plugin name
+        id: get_plugin_name
+        run: |
+          PLUGIN_BUNDLE=$(find . -maxdepth 1 -iname "*.indigoPlugin" -type d | head -1)
+          if [ -z "$PLUGIN_BUNDLE" ]; then
+            echo "Error: No .indigoPlugin directory found in repository root." >&2
+            exit 1
+          fi
+          PLUGIN_NAME=$(basename "$PLUGIN_BUNDLE" .indigoPlugin)
+          echo "plugin_name=$PLUGIN_NAME" >> $GITHUB_OUTPUT
+          echo "Detected plugin name: $PLUGIN_NAME"
+
       - name: Extract version from Info.plist
         id: get_version
         run: |
-          VERSION=$(grep -A1 '<key>PluginVersion</key>' UKTrains.indigoPlugin/Contents/Info.plist | grep '<string>' | sed 's/.*<string>\(.*\)<\/string>.*/\1/')
+          PLUGIN_NAME="${{ steps.get_plugin_name.outputs.plugin_name }}"
+          VERSION=$(grep -A1 '<key>PluginVersion</key>' "${PLUGIN_NAME}.indigoPlugin/Contents/Info.plist" | grep '<string>' | sed 's/.*<string>\(.*\)<\/string>.*/\1/')
+          if [ -z "$VERSION" ]; then
+            echo "Error: Could not extract PluginVersion from Info.plist." >&2
+            exit 1
+          fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Extracted version: $VERSION"
 
@@ -39,9 +56,18 @@ jobs:
       - name: Create plugin bundle zip
         if: steps.check_release.outputs.exists == 'false'
         run: |
-          VERSION="${{ steps.get_version.outputs.version }}"
-          zip -r "UKTrains.indigoPlugin.zip" "UKTrains.indigoPlugin"
-          echo "Created UKTrains.indigoPlugin.zip"
+          PLUGIN_NAME="${{ steps.get_plugin_name.outputs.plugin_name }}"
+          zip -r "${PLUGIN_NAME}.indigoPlugin.zip" "${PLUGIN_NAME}.indigoPlugin" \
+            -x "*.pyc" \
+            -x "*/__pycache__" \
+            -x "*/__pycache__/*" \
+            -x "*.sublime-project" \
+            -x "*.sublime-workspace" \
+            -x "*/.idea" \
+            -x "*/.idea/*" \
+            -x "*.bbproject" \
+            -x "*.bbproject/*"
+          echo "Created ${PLUGIN_NAME}.indigoPlugin.zip"
 
       - name: Create GitHub Release
         if: steps.check_release.outputs.exists == 'false'
@@ -52,4 +78,4 @@ jobs:
           generate_release_notes: true
           draft: false
           prerelease: false
-          files: UKTrains.indigoPlugin.zip
+          files: ${{ steps.get_plugin_name.outputs.plugin_name }}.indigoPlugin.zip

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -15,23 +15,23 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Determine plugin name
-        id: get_plugin_name
+      - name: Determine plugin bundle
+        id: get_plugin
         run: |
-          PLUGIN_BUNDLE=$(find . -maxdepth 1 -iname "*.indigoPlugin" -type d | head -1)
-          if [ -z "$PLUGIN_BUNDLE" ]; then
+          PLUGIN_BUNDLE_PATH=$(find . -maxdepth 1 -iname "*.indigoPlugin" -type d | head -1)
+          if [ -z "$PLUGIN_BUNDLE_PATH" ]; then
             echo "Error: No .indigoPlugin directory found in repository root." >&2
             exit 1
           fi
-          PLUGIN_NAME=$(basename "$PLUGIN_BUNDLE" .indigoPlugin)
-          echo "plugin_name=$PLUGIN_NAME" >> $GITHUB_OUTPUT
-          echo "Detected plugin name: $PLUGIN_NAME"
+          PLUGIN_BUNDLE=$(basename "$PLUGIN_BUNDLE_PATH")
+          echo "plugin_bundle=$PLUGIN_BUNDLE" >> $GITHUB_OUTPUT
+          echo "Detected plugin bundle: $PLUGIN_BUNDLE"
 
       - name: Extract version from Info.plist
         id: get_version
         run: |
-          PLUGIN_NAME="${{ steps.get_plugin_name.outputs.plugin_name }}"
-          VERSION=$(grep -A1 '<key>PluginVersion</key>' "${PLUGIN_NAME}.indigoPlugin/Contents/Info.plist" | grep '<string>' | sed 's/.*<string>\(.*\)<\/string>.*/\1/')
+          PLUGIN_BUNDLE="${{ steps.get_plugin.outputs.plugin_bundle }}"
+          VERSION=$(grep -A1 '<key>PluginVersion</key>' "${PLUGIN_BUNDLE}/Contents/Info.plist" | grep '<string>' | sed 's/.*<string>\(.*\)<\/string>.*/\1/')
           if [ -z "$VERSION" ]; then
             echo "Error: Could not extract PluginVersion from Info.plist." >&2
             exit 1

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -15,10 +15,27 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Determine plugin name
+        id: get_plugin_name
+        run: |
+          PLUGIN_BUNDLE=$(find . -maxdepth 1 -iname "*.indigoPlugin" -type d | head -1)
+          if [ -z "$PLUGIN_BUNDLE" ]; then
+            echo "Error: No .indigoPlugin directory found in repository root." >&2
+            exit 1
+          fi
+          PLUGIN_NAME=$(basename "$PLUGIN_BUNDLE" .indigoPlugin)
+          echo "plugin_name=$PLUGIN_NAME" >> $GITHUB_OUTPUT
+          echo "Detected plugin name: $PLUGIN_NAME"
+
       - name: Extract version from Info.plist
         id: get_version
         run: |
-          VERSION=$(grep -A1 '<key>PluginVersion</key>' UKTrains.indigoPlugin/Contents/Info.plist | grep '<string>' | sed 's/.*<string>\(.*\)<\/string>.*/\1/')
+          PLUGIN_NAME="${{ steps.get_plugin_name.outputs.plugin_name }}"
+          VERSION=$(grep -A1 '<key>PluginVersion</key>' "${PLUGIN_NAME}.indigoPlugin/Contents/Info.plist" | grep '<string>' | sed 's/.*<string>\(.*\)<\/string>.*/\1/')
+          if [ -z "$VERSION" ]; then
+            echo "Error: Could not extract PluginVersion from Info.plist." >&2
+            exit 1
+          fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Extracted version: $VERSION"
 
@@ -29,7 +46,6 @@ jobs:
             echo "::error::Version v$VERSION already exists as a git tag. Please update the PluginVersion in Info.plist."
             exit 1
           fi
-          # Also check without 'v' prefix
           if git rev-parse "$VERSION" >/dev/null 2>&1; then
             echo "::error::Version $VERSION already exists as a git tag. Please update the PluginVersion in Info.plist."
             exit 1

--- a/UKTrains.indigoPlugin/Contents/Info.plist
+++ b/UKTrains.indigoPlugin/Contents/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>PluginVersion</key>
-	<string>2026.1.0</string>
+	<string>2026.1.1</string>
 	<key>ServerApiVersion</key>
 	<string>3.0</string>
 	<key>IwsApiVersion</key>


### PR DESCRIPTION
## Summary
- Replace existing `version-check.yml` + `create-release.yml` with the canonical templates from [`indigo-claude-plugin`](https://github.com/simons-plugins/indigo-claude-plugin/blob/main/docs/plugin-dev/workflows/).
- This repo was the closest to the canonical pair already (v-prefix tags, action@v2, `git rev-parse`) — main change is dropping the hardcoded `UKTrains.indigoPlugin` reference in favour of `find -iname '*.indigoPlugin'` auto-detection. Adds zip exclusions for `.pyc` / `__pycache__` / IDE files (was zipping everything).

## Why
Final repo in the workspace-wide rollout to standardize CI across all 11 Indigo plugin repos.

## Test plan
- [ ] version-check passes
- [ ] After merge: `create-release` produces `v2026.1.1` tag + release with `UKTrains.indigoPlugin.zip`
- [ ] `test.yml` (pytest) is independent and unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)