### PR TITLE
fix: CFBundleVersion must be 1.0.0 (plugin-store validation)

### DIFF
--- a/UKTrains.indigoPlugin/Contents/Info.plist
+++ b/UKTrains.indigoPlugin/Contents/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>PluginVersion</key>
-	<string>2026.1.1</string>
+	<string>2026.1.2</string>
 	<key>ServerApiVersion</key>
 	<string>3.0</string>
 	<key>IwsApiVersion</key>
@@ -13,7 +13,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.simons-plugins.UKTrains</string>
 	<key>CFBundleVersion</key>
-	<string>1.0.1</string>
+	<string>1.0.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
Indigo plugin-store validation (reported by Jay for indigo-matter, swept across all workspace plugins) requires `CFBundleVersion` to be `1.0.0` — it identifies the bundle layout and is controlled by Indigo, distinct from `PluginVersion`.

- `CFBundleVersion`: `1.0.1` → `1.0.0`
- `PluginVersion`: `2026.1.1` → `2026.1.2` (patch bump for version-check CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)