### PR TITLE
ci: fail the build if CFBundleVersion is too long for the Plugin Store

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -51,3 +51,22 @@ jobs:
             exit 1
           fi
           echo "✓ Version $VERSION is new and can be released."
+
+      - name: Check CFBundleVersion fits the Plugin Store
+        run: |
+          PLIST=$(find . -maxdepth 3 -ipath "*.indigoplugin/Contents/Info.plist" | head -1)
+          if [ -z "$PLIST" ]; then
+            echo "::error::No .indigoPlugin/Contents/Info.plist found." >&2
+            exit 1
+          fi
+          BUNDLE_VERSION=$(grep -A1 '<key>CFBundleVersion</key>' "$PLIST" | grep '<string>' | sed 's/.*<string>\(.*\)<\/string>.*/\1/')
+          if [ -z "$BUNDLE_VERSION" ]; then
+            echo "::error::Could not read CFBundleVersion from $PLIST." >&2
+            exit 1
+          fi
+          echo "CFBundleVersion: $BUNDLE_VERSION (${#BUNDLE_VERSION} characters)"
+          if [ ${#BUNDLE_VERSION} -gt 8 ]; then
+            echo "::error::CFBundleVersion '$BUNDLE_VERSION' is ${#BUNDLE_VERSION} characters. The Indigo Plugin Store stores it in a varchar(8) column, so anything longer fails ingestion with \"1406 (22001): Data too long for column 'bundleVersion'\" and the store silently stops picking up releases. CFBundleVersion is the bundle-layout version, not the release version (that is PluginVersion) — use a short static value such as 1.0.0."
+            exit 1
+          fi
+          echo "CFBundleVersion fits the store's 8-character column."

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -52,21 +52,38 @@ jobs:
           fi
           echo "✓ Version $VERSION is new and can be released."
 
-      - name: Check CFBundleVersion fits the Plugin Store
+      - name: Validate Info.plist version keys
         run: |
           PLIST=$(find . -maxdepth 3 -ipath "*.indigoplugin/Contents/Info.plist" | head -1)
           if [ -z "$PLIST" ]; then
             echo "::error::No .indigoPlugin/Contents/Info.plist found." >&2
             exit 1
           fi
-          BUNDLE_VERSION=$(grep -A1 '<key>CFBundleVersion</key>' "$PLIST" | grep '<string>' | sed 's/.*<string>\(.*\)<\/string>.*/\1/')
-          if [ -z "$BUNDLE_VERSION" ]; then
-            echo "::error::Could not read CFBundleVersion from $PLIST." >&2
-            exit 1
+          read_key() { grep -A1 "<key>$1</key>" "$PLIST" | grep '<string>' | sed 's/.*<string>\(.*\)<\/string>.*/\1/'; }
+          PLUGIN_VERSION=$(read_key PluginVersion)
+          BUNDLE_VERSION=$(read_key CFBundleVersion)
+          fail=0
+          # Plugin Developer's Guide, "General Rules": version numbers in Info.plist
+          # must be of the form X.Y.Z — digits and periods only, no beta or
+          # pre-release signifiers.
+          for pair in "PluginVersion:$PLUGIN_VERSION" "CFBundleVersion:$BUNDLE_VERSION"; do
+            key=${pair%%:*}; val=${pair#*:}
+            if [ -z "$val" ]; then
+              echo "::error::$key is missing from $PLIST."; fail=1; continue
+            fi
+            if ! printf '%s' "$val" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+              echo "::error::$key is '$val'. The Plugin Developer's Guide requires the form X.Y.Z — digits and periods only, no beta or pre-release signifiers."
+              fail=1
+            fi
+          done
+          # UNDOCUMENTED store limit: the Plugin Store keeps CFBundleVersion in a
+          # varchar(8) column. Longer values fail ingestion with "1406 (22001): Data
+          # too long for column 'bundleVersion'" and the store silently stops picking
+          # up releases. Note 2026.2.12 satisfies X.Y.Z yet still breaks it, which is
+          # why this needs its own check.
+          if [ -n "$BUNDLE_VERSION" ] && [ ${#BUNDLE_VERSION} -gt 8 ]; then
+            echo "::error::CFBundleVersion '$BUNDLE_VERSION' is ${#BUNDLE_VERSION} characters; the Plugin Store column holds 8. Per the Plugin Developer's Guide CFBundleVersion 'represents the layout of the bundle' and 'is controlled by us' (Indigo Domotics) — it is not your release version (that is PluginVersion). Use a short static value such as 1.0.0 and do not bump it per release."
+            fail=1
           fi
-          echo "CFBundleVersion: $BUNDLE_VERSION (${#BUNDLE_VERSION} characters)"
-          if [ ${#BUNDLE_VERSION} -gt 8 ]; then
-            echo "::error::CFBundleVersion '$BUNDLE_VERSION' is ${#BUNDLE_VERSION} characters. The Indigo Plugin Store stores it in a varchar(8) column, so anything longer fails ingestion with \"1406 (22001): Data too long for column 'bundleVersion'\" and the store silently stops picking up releases. CFBundleVersion is the bundle-layout version, not the release version (that is PluginVersion) — use a short static value such as 1.0.0."
-            exit 1
-          fi
-          echo "CFBundleVersion fits the store's 8-character column."
+          [ $fail -eq 0 ] || exit 1
+          echo "PluginVersion=$PLUGIN_VERSION  CFBundleVersion=$BUNDLE_VERSION (${#BUNDLE_VERSION} chars) - OK"

--- a/UKTrains.indigoPlugin/Contents/Info.plist
+++ b/UKTrains.indigoPlugin/Contents/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>PluginVersion</key>
-	<string>2026.1.2</string>
+	<string>2026.1.3</string>
 	<key>ServerApiVersion</key>
 	<string>3.0</string>
 	<key>IwsApiVersion</key>


### PR DESCRIPTION
The Indigo Plugin Store stores `CFBundleVersion` in a **varchar(8)** column. Anything longer fails ingestion with:

```
(1406, "1406 (22001): Data too long for column 'bundleVersion' at row 1", '22001')
```

...and the store silently stops picking up releases. `indigo-matter` hit this: 18 releases (v2026.2.10 – v2026.3.0) carried a 9-character `CFBundleVersion` of `2026.2.12`, and the store kept re-polling the first bad one instead of advancing. It went unnoticed for five months until Indigo support emailed about it.

`version-check.yml` already validates `PluginVersion` but never looked at `CFBundleVersion` — which is exactly how that shipped.

## What this adds

One step asserting `CFBundleVersion` is at most 8 characters, with an error message that names the real cause and the fix. It is self-contained (finds the plist itself) so the same step works regardless of whether the workflow has a `get_plugin` step.

`CFBundleVersion` is the **bundle-layout** version, not the release version — that is `PluginVersion`. A short static value such as `1.0.0` is correct and never grows.

Applied across all 14 plugin repos that have `version-check.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated release validation to enforce version consistency and ensure compliance with deployment standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->